### PR TITLE
Add benchmarks and optimize CanConvert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 
 # NUnit output
 TestResult.xml
+
+# BenchmarkDotNet output
+BenchmarkDotNet.Artifacts

--- a/src/NodaTime.Serialization.Benchmarks/JsonNet/NodaConverterBaseBenchmarks.cs
+++ b/src/NodaTime.Serialization.Benchmarks/JsonNet/NodaConverterBaseBenchmarks.cs
@@ -1,0 +1,70 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using BenchmarkDotNet.Attributes;
+using Newtonsoft.Json;
+using NodaTime.Serialization.JsonNet;
+using System.IO;
+
+namespace NodaTime.Serialization.Benchmarks.JsonNet
+{
+    public class NodaConverterBaseBenchmarks
+    {
+        private readonly NodaConverterBase<int> int32Converter = new DummyConverter<int>();
+        private readonly NodaConverterBase<string> stringConverter = new DummyConverter<string>();
+        private readonly NodaConverterBase<Stream> streamConverter = new DummyConverter<Stream>();
+
+        // Value types
+        [Benchmark]
+        public bool CanConvert_Int32_Int32() => int32Converter.CanConvert(typeof(int));
+
+        [Benchmark]
+        public bool CanConvert_Int32_NullableInt32() => int32Converter.CanConvert(typeof(int?));
+
+        [Benchmark]
+        public bool CanConvert_Int32_Object() => int32Converter.CanConvert(typeof(object));
+
+        [Benchmark]
+        public bool CanConvert_Int32_String() => int32Converter.CanConvert(typeof(string));
+
+        [Benchmark]
+        public bool CanConvert_Int32_UInt32() => int32Converter.CanConvert(typeof(uint));
+
+        // Sealed classes
+        [Benchmark]
+        public bool CanConvert_String_String() => stringConverter.CanConvert(typeof(string));
+
+        [Benchmark]
+        public bool CanConvert_String_Object() => stringConverter.CanConvert(typeof(object));
+
+        [Benchmark]
+        public bool CanConvert_String_UInt32() => stringConverter.CanConvert(typeof(uint));
+
+        // Unsealed classes
+        [Benchmark]
+        public bool CanConvert_Stream_Stream() => streamConverter.CanConvert(typeof(Stream));
+
+        [Benchmark]
+        public bool CanConvert_Stream_MemoryStream() => streamConverter.CanConvert(typeof(MemoryStream));
+
+        [Benchmark]
+        public bool CanConvert_Stream_Object() => streamConverter.CanConvert(typeof(object));
+
+        [Benchmark]
+        public bool CanConvert_Stream_String() => streamConverter.CanConvert(typeof(string));
+
+        [Benchmark]
+        public bool CanConvert_Stream_UInt32() => streamConverter.CanConvert(typeof(uint));
+
+        private class DummyConverter<T> : NodaConverterBase<T>
+        {
+            protected override T ReadJsonImpl(JsonReader reader, JsonSerializer serializer) => default(T);
+
+            protected override void WriteJsonImpl(JsonWriter writer, T value, JsonSerializer serializer)
+            {
+                writer.WriteValue(value.ToString());
+            }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Benchmarks/NodaTime.Serialization.Benchmarks.csproj
+++ b/src/NodaTime.Serialization.Benchmarks/NodaTime.Serialization.Benchmarks.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <AssemblyOriginatorKeyFile>../../NodaTime Release.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <Deterministic>True</Deterministic>
+    <IsPackable>False</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NodaTime.Serialization.JsonNet\NodaTime.Serialization.JsonNet.csproj" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.3" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+    <DefineConstants>$(DefineConstants);PCL</DefineConstants>
+  </PropertyGroup>
+
+</Project>

--- a/src/NodaTime.Serialization.Benchmarks/Program.cs
+++ b/src/NodaTime.Serialization.Benchmarks/Program.cs
@@ -1,0 +1,21 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using BenchmarkDotNet.Running;
+using System.Reflection;
+
+namespace NodaTime.Serialization.Benchmarks
+{
+    /// <summary>
+    /// Entry point for benchmarking.
+    /// </summary>
+    public class Program
+    {
+        // Run it with args = { "*" } for choosing all of target benchmarks
+        public static void Main(string[] args)
+        {
+            new BenchmarkSwitcher(typeof(Program).GetTypeInfo().Assembly).Run(args);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.sln
+++ b/src/NodaTime.Serialization.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaTime.Serialization.Test", "NodaTime.Serialization.Test\NodaTime.Serialization.Test.csproj", "{07063FD8-A2C2-43FB-A52C-093F4FB3F483}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaTime.Serialization.JsonNet", "NodaTime.Serialization.JsonNet\NodaTime.Serialization.JsonNet.csproj", "{40445ECC-0F53-4ED2-A764-C6F81410DF73}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NodaTime.Serialization.Benchmarks", "NodaTime.Serialization.Benchmarks\NodaTime.Serialization.Benchmarks.csproj", "{7E96596E-800E-4F71-9304-F1D0F6B9937B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Significant improvement for #12.

Benchmark results:

Before:

```
 |                         Method |       Mean |    StdErr |    StdDev |     Median |
 |------------------------------- |----------- |---------- |---------- |----------- |
 |         CanConvert_Int32_Int32 | 32.3227 ns | 0.1344 ns | 0.5205 ns | 32.2007 ns |
 | CanConvert_Int32_NullableInt32 | 51.1027 ns | 0.3238 ns | 1.2117 ns | 51.0040 ns |
 |        CanConvert_Int32_Object | 49.7077 ns | 0.5168 ns | 2.1924 ns | 49.0883 ns |
 |        CanConvert_Int32_String | 51.6088 ns | 0.4570 ns | 1.7101 ns | 51.0255 ns |
 |        CanConvert_Int32_UInt32 | 53.4829 ns | 0.5534 ns | 3.4115 ns | 53.3924 ns |
 |       CanConvert_String_String | 34.2702 ns | 0.3612 ns | 2.0750 ns | 33.3913 ns |
 |       CanConvert_String_Object | 50.7273 ns | 0.4690 ns | 1.7547 ns | 50.2128 ns |
 |       CanConvert_String_UInt32 | 51.9694 ns | 0.2787 ns | 1.0427 ns | 52.1386 ns |
 |       CanConvert_Stream_Stream | 34.1380 ns | 0.0557 ns | 0.1929 ns | 34.1391 ns |
 | CanConvert_Stream_MemoryStream | 49.8007 ns | 0.5182 ns | 4.0472 ns | 49.0353 ns |
 |       CanConvert_Stream_Object | 52.3670 ns | 0.5382 ns | 3.9549 ns | 50.5785 ns |
 |       CanConvert_Stream_String | 50.1581 ns | 0.2479 ns | 0.9274 ns | 49.7345 ns |
 |       CanConvert_Stream_UInt32 | 51.7420 ns | 0.3143 ns | 1.0888 ns | 51.7160 ns |
```

After:

```
 |                         Method |       Mean |    StdDev |
 |------------------------------- |----------- |---------- |
 |         CanConvert_Int32_Int32 |  3.7360 ns | 0.0923 ns |
 | CanConvert_Int32_NullableInt32 |  7.2751 ns | 0.0991 ns |
 |        CanConvert_Int32_Object |  7.5882 ns | 0.2187 ns |
 |        CanConvert_Int32_String |  8.0872 ns | 0.2671 ns |
 |        CanConvert_Int32_UInt32 |  7.6310 ns | 0.2044 ns |
 |       CanConvert_String_String |  4.7130 ns | 0.0883 ns |
 |       CanConvert_String_Object | 15.9726 ns | 0.4164 ns |
 |       CanConvert_String_UInt32 | 15.1037 ns | 0.1784 ns |
 |       CanConvert_Stream_Stream |  4.6459 ns | 0.1040 ns |
 | CanConvert_Stream_MemoryStream | 52.7746 ns | 1.0389 ns |
 |       CanConvert_Stream_Object | 52.0123 ns | 0.8069 ns |
 |       CanConvert_Stream_String | 53.4943 ns | 1.4109 ns |
 |       CanConvert_Stream_UInt32 | 55.4518 ns | 1.6362 ns |
```

Out of our 11 converters:

- 9 are for value types (LocalDate, LocalDateTime, LocalTime, Instant, Offset, OffsetDateTime, ZonedDateTime, Offset, Duration, Interval)
- 1 is for a sealed class (Period)
- 1 is for an unsealed class (DateTimeZone) - this is the one that wouldn't see any improvement, yet at least

So I expect this to have a pretty significant impact.

@willdean: How easily would you be able to test this, either before or after a merge?