### PR TITLE
Protobuf conversions (new project)

### DIFF
--- a/src/NodaTime.Serialization.JsonNet/NodaConverterBase.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaConverterBase.cs
@@ -52,10 +52,9 @@ namespace NodaTime.Serialization.JsonNet
         {
             if (reader.TokenType == JsonToken.Null)
             {
-                if (objectType != NullableT)
-                {
-                    throw new InvalidNodaDataException($"Cannot convert null value to {objectType}.");
-                }
+                Preconditions.CheckData(objectType == NullableT,
+                    "Cannot convert null value to {0}",
+                    objectType);
                 return null;
             }
 
@@ -65,10 +64,9 @@ namespace NodaTime.Serialization.JsonNet
                 string value = (string) reader.Value;
                 if (value == "")
                 {
-                    if (objectType != NullableT)
-                    {
-                        throw new InvalidNodaDataException($"Cannot convert null value to {objectType}.");
-                    }
+                    Preconditions.CheckData(objectType == NullableT,
+                        "Cannot convert null value to {0}",
+                        objectType);
                     return null;
                 }
             }
@@ -99,18 +97,16 @@ namespace NodaTime.Serialization.JsonNet
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             // Json.NET should prevent this happening, but let's validate...
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            Preconditions.CheckNotNull(value, nameof(value));
 
             // Note: don't need to worry about value is T? due to the way boxing works.
             // Again, Json.NET probably prevents us from needing to check this, really.
-            if (!(value is T))
+            if (value is T castValue)
             {
-                throw new ArgumentException($"Unexpected value when converting. Expected {typeof (T).FullName}, got {value.GetType().FullName}.");
+                WriteJsonImpl(writer, castValue, serializer);
+                return;
             }
-            WriteJsonImpl(writer, (T)value, serializer);
+            throw new ArgumentException($"Unexpected value when converting. Expected {typeof(T).FullName}, got {value.GetType().FullName}.");
         }
 
         /// <summary>

--- a/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
@@ -109,11 +109,9 @@ namespace NodaTime.Serialization.JsonNet
         {
             var calendar = calendarProjection(value);
             // We rely on CalendarSystem.Iso being a singleton here.
-            if (calendar != CalendarSystem.Iso)
-            {
-                throw new ArgumentException(
-                    $"Values of type {typeof(T).Name} must (currently) use the ISO calendar in order to be serialized.");
-            }
+            Preconditions.CheckArgument(calendar == CalendarSystem.Iso,
+                "Values of type {0} must (currently) use the ISO calendar in order to be serialized.",
+                typeof(T).Name);
         };
     }
 }

--- a/src/NodaTime.Serialization.JsonNet/NodaDateTimeZoneConverter.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaDateTimeZoneConverter.cs
@@ -30,11 +30,9 @@ namespace NodaTime.Serialization.JsonNet
         /// <returns>The <see cref="DateTimeZone"/> identified in the JSON, or null.</returns>
         protected override DateTimeZone ReadJsonImpl(JsonReader reader, JsonSerializer serializer)
         {
-            if (reader.TokenType != JsonToken.String)
-            {
-                throw new InvalidNodaDataException(
-                    $"Unexpected token parsing instant. Expected String, got {reader.TokenType}.");
-            }
+            Preconditions.CheckData(reader.TokenType == JsonToken.String,
+                "Unexpected token parsing instant. Expected String, got {0}.",
+                reader.TokenType);
 
             var timeZoneId = reader.Value.ToString();
             return provider[timeZoneId];

--- a/src/NodaTime.Serialization.JsonNet/NodaPatternConverter.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaPatternConverter.cs
@@ -37,12 +37,7 @@ namespace NodaTime.Serialization.JsonNet
         /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is null.</exception>
         public NodaPatternConverter(IPattern<T> pattern, Action<T> validator)
         {
-            // Note: We could use Preconditions.CheckNotNull, but only if we either made that public in NodaTime
-            // or made InternalsVisibleTo this assembly. 
-            if (pattern == null)
-            {
-                throw new ArgumentNullException(nameof(pattern));
-            }
+            Preconditions.CheckNotNull(pattern, nameof(pattern));
             this.pattern = pattern;
             this.validator = validator;
         }

--- a/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
+++ b/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
@@ -11,12 +11,10 @@
     <AssemblyOriginatorKeyFile>../../NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>NodaTime.Serialization.JsonNet</PackageId>
     <PackageTags>nodatime;json;jsonnet</PackageTags>
     <PackageProjectUrl>http://nodatime.org/</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/nodatime/nodatime.git</RepositoryUrl>
-    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+    <RepositoryUrl>https://github.com/nodatime/nodatime.serialization</RepositoryUrl>
     <Deterministic>True</Deterministic>
     <IncludeSymbols>True</IncludeSymbols>
     <IncludeSource>True</IncludeSource>
@@ -26,9 +24,5 @@
     <PackageReference Include="NodaTime" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);PCL</DefineConstants>
-  </PropertyGroup>
 
 </Project>

--- a/src/NodaTime.Serialization.JsonNet/Preconditions.cs
+++ b/src/NodaTime.Serialization.JsonNet/Preconditions.cs
@@ -1,0 +1,35 @@
+// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Utility;
+using System;
+
+namespace NodaTime.Serialization.JsonNet
+{
+    /// <summary>
+    /// Helper static methods for argument/state validation. (Just the subset used within this library.)
+    /// </summary>
+    internal static class Preconditions
+    {
+        internal static T CheckNotNull<T>(T argument, string paramName) where T : class
+            => argument ?? throw new ArgumentNullException(paramName);
+        
+        internal static void CheckArgument(bool expression, string parameter, string message)
+        {
+            if (!expression)
+            {
+                throw new ArgumentException(message, parameter);
+            }
+        }
+
+        internal static void CheckData<T>(bool expression, string messageFormat, T messageArg)
+        {
+            if (!expression)
+            {
+                string message = string.Format(messageFormat, messageArg);
+                throw new InvalidNodaDataException(message);
+            }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.JsonNet/Properties/AssemblyInfo.cs
+++ b/src/NodaTime.Serialization.JsonNet/Properties/AssemblyInfo.cs
@@ -3,7 +3,5 @@
 // as found in the LICENSE.txt file.
 
 using System;
-using System.Resources;
 
 [assembly: CLSCompliant(true)]
-[assembly: NeutralResourcesLanguage("en")]

--- a/src/NodaTime.Serialization.Protobuf/AssemblyInfo.cs
+++ b/src/NodaTime.Serialization.Protobuf/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("NodaTime.Serialization.Test,"
+    + "PublicKey=0024000004800000940000000602000000240000525341310004000001000100d335797ef2bff7"
+    + "4db7c046f874523c553f88d3f8e0c2ba769820c54f0e64a11b47198b544c74abb487f8d3b64669"
+    + "08ae2ac6fced4738e46a75e5661d5ac03fb29c7e26b13a220400cb9df95134e85716203f83b96f"
+    + "ab661135c39b10f33e1c467a6750d8af331c602351b09a7bf5dd3a8943712d676481c5054c8031"
+    + "84f77ed5")]

--- a/src/NodaTime.Serialization.Protobuf/NodaExtensions.cs
+++ b/src/NodaTime.Serialization.Protobuf/NodaExtensions.cs
@@ -1,0 +1,116 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Google.Protobuf.WellKnownTypes;
+using Google.Type;
+using System;
+using NodaDuration = NodaTime.Duration;
+using ProtobufDuration = Google.Protobuf.WellKnownTypes.Duration;
+using ProtobufDayOfWeek = Google.Type.DayOfWeek;
+
+namespace NodaTime.Serialization.Protobuf
+{
+    /// <summary>
+    /// Extension methods on the Google.Protobuf time-related types to convert them to Noda Time types.
+    /// </summary>
+    public static class NodaExtensions
+    {
+        private static readonly NodaDuration minProtobufDuration =
+            NodaDuration.FromSeconds(ProtobufDuration.MinSeconds - 1) + NodaDuration.FromNanoseconds(1);
+
+        private static readonly NodaDuration maxProtobufDuration =
+            NodaDuration.FromSeconds(ProtobufDuration.MaxSeconds + 1) - NodaDuration.FromNanoseconds(1);
+
+        /// <summary>
+        /// Converts a Noda Time <see cref="NodaDuration"/> to a Protobuf <see cref="ProtobufDuration"/>.
+        /// </summary>
+        /// <remarks>
+        /// Noda Time has a wider range of valid durations than Protobuf; durations of more than around 10,000
+        /// years (positive or negative) cannot be represented.
+        /// </remarks>
+        /// <param name="duration">The duration to convert. Must not be null.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="duration"/> represents a duration
+        /// which is invalid in <see cref="ProtobufDuration"/>.</exception>
+        /// <returns>The Protobuf representation.</returns>
+        public static ProtobufDuration ToProtobufDuration(this NodaDuration duration)
+        {
+            if (duration < minProtobufDuration || duration > maxProtobufDuration)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Duration is outside the range of valid Protobuf durations.");
+            }
+            // Deliberately long to keep the later arithmetic in 64-bit.
+            long days = duration.Days;
+            long nanoOfDay = duration.NanosecondOfDay;
+            long secondOfDay = nanoOfDay / NodaConstants.NanosecondsPerSecond;
+            int nanos = duration.SubsecondNanoseconds;
+            return new ProtobufDuration { Seconds = days * NodaConstants.SecondsPerDay + secondOfDay, Nanos = nanos };
+        }
+
+        /// <summary>
+        /// Converts a Noda Time <see cref="Instant"/> to a Protobuf <see cref="Timestamp"/>.
+        /// </summary>
+        /// <remarks>
+        /// Noda Time has a wider range of valid instants than Protobuf timestamps; instants before 0001-01-01 CE
+        /// are out of range.
+        /// </remarks>
+        /// <param name="instant">The instant to convert.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="instant"/> represents an instant
+        /// which is invalid in <see cref="Timestamp"/>.</exception>
+        /// <returns>The Protobuf representation.</returns>
+        public static Timestamp ToTimestamp(this Instant instant)
+        {
+            if (instant < NodaConstants.BclEpoch)
+            {
+                throw new ArgumentOutOfRangeException(nameof(instant), "Instant is outside the range of Valid Protobuf timestamps");
+            }
+            // Truncated towards the start of time, which is what we want...
+            var seconds = instant.ToUnixTimeSeconds();
+            var remainder = instant - Instant.FromUnixTimeSeconds(seconds);
+            // NanosecondOfDay is probably the most efficient way of turning a small, subsecond, non-negative duration
+            // into a number of nanoseconds...
+            return new Timestamp { Seconds = seconds, Nanos = (int) remainder.NanosecondOfDay };
+        }
+
+        /// <summary>
+        /// Converts a Noda Time <see cref="LocalTime"/> to a Protobuf <see cref="TimeOfDay"/>.
+        /// </summary>
+        /// <remarks>
+        /// Every valid Noda Time local time can be represented in Protobuf without loss of information.
+        /// </remarks>
+        /// <param name="localTime">The local time.</param>
+        /// <returns>The Protobuf representation.</returns>
+        public static TimeOfDay ToTimeOfDay(this LocalTime localTime)
+        {
+            return new TimeOfDay
+            {
+                Hours = localTime.Hour,
+                Minutes = localTime.Minute,
+                Seconds = localTime.Second,
+                Nanos = localTime.NanosecondOfSecond
+            };
+        }
+
+        /// <summary>
+        /// Converts a Protobuf <see cref="ProtobufDayOfWeek"/> to a Noda Time <see cref="IsoDayOfWeek"/>.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="ProtobufDayOfWeek.Unspecified"/> value maps to <see cref="IsoDayOfWeek.None"/>.
+        /// </remarks>
+        /// <param name="isoDayOfWeek">The ISO day-of-week value to convert.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="isoDayOfWeek"/> is neither None nor
+        /// a valid ISO day-of-week value.</exception>
+        /// <returns>The Protobuf representation.</returns>
+        public static ProtobufDayOfWeek ToProtobufDayOfWeek(this IsoDayOfWeek isoDayOfWeek)
+        {
+            // Preconditions doesn't have an enum version.
+            if (isoDayOfWeek < 0 || isoDayOfWeek > IsoDayOfWeek.Sunday)
+            {
+                throw new ArgumentOutOfRangeException(nameof(isoDayOfWeek), isoDayOfWeek,
+                    "Only valid day-of-week values (or None) may be converted");
+            }
+            // Handily, Noda Time and Protobuf use the same numbers.
+            return (ProtobufDayOfWeek) isoDayOfWeek;
+        }   
+    }
+}

--- a/src/NodaTime.Serialization.Protobuf/NodaTime.Serialization.Protobuf.csproj
+++ b/src/NodaTime.Serialization.Protobuf/NodaTime.Serialization.Protobuf.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Provides serialization support between Noda Time and Google.Protobuf</Description>
+    <AssemblyTitle>Noda Time</AssemblyTitle>
+    <VersionPrefix>1.0.0-alpha01</VersionPrefix>
+    <Authors>Jon Skeet</Authors>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyOriginatorKeyFile>../../NodaTime Release.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PackageTags>nodatime;google;protobuf</PackageTags>
+    <PackageProjectUrl>http://nodatime.org/</PackageProjectUrl>
+    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/nodatime/nodatime.serialization</RepositoryUrl>
+    <Deterministic>True</Deterministic>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NodaTime" Version="2.0.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="1.1.0" />
+  </ItemGroup>
+</Project>

--- a/src/NodaTime.Serialization.Protobuf/Preconditions.cs
+++ b/src/NodaTime.Serialization.Protobuf/Preconditions.cs
@@ -1,0 +1,35 @@
+// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+
+namespace NodaTime.Serialization.Protobuf
+{
+    /// <summary>
+    /// Helper static methods for argument/state validation. (Just the subset used within this library.)
+    /// </summary>
+    internal static class Preconditions
+    {
+        internal static T CheckNotNull<T>(T argument, string paramName) where T : class
+            => argument ?? throw new ArgumentNullException(paramName);
+
+        internal static void CheckArgument<T>(bool expression, string parameter, string messageFormat, T messageArg)
+        {
+            if (!expression)
+            {
+                string message = string.Format(messageFormat, messageArg);
+                throw new ArgumentException(message, parameter);
+            }
+        }
+
+        internal static void CheckArgument<T1, T2>(bool expression, string parameter, string messageFormat, T1 messageArg1, T2 messageArg2)
+        {
+            if (!expression)
+            {
+                string message = string.Format(messageFormat, messageArg1, messageArg2);
+                throw new ArgumentException(message, parameter);
+            }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Protobuf/ProtobufExtensions.cs
+++ b/src/NodaTime.Serialization.Protobuf/ProtobufExtensions.cs
@@ -1,0 +1,136 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Google.Protobuf.WellKnownTypes;
+using Google.Type;
+using System;
+using NodaDuration = NodaTime.Duration;
+using ProtobufDuration = Google.Protobuf.WellKnownTypes.Duration;
+using ProtobufDayOfWeek = Google.Type.DayOfWeek;
+
+namespace NodaTime.Serialization.Protobuf
+{
+    /// <summary>
+    /// Extension methods on the Google.Protobuf time-related types to convert them to Noda Time types.
+    /// </summary>
+    public static class ProtobufExtensions
+    {
+        // These correspond to 0001-01-01T00:00:00 and 9999-12-31T23:59:59 respectively.
+        // They are checked in ProtobufExtensiosnTest.cs.
+        internal const long MinValidTimestampSeconds = -62135596800L;
+        internal const long MaxValidTimestampSeconds = 253402300799;
+
+        /// <summary>
+        /// Converts a Protobuf <see cref="ProtobufDuration"/> to a Noda Time <see cref="NodaDuration"/>.
+        /// </summary>
+        /// <remarks>
+        /// Every valid Protobuf duration can be represented in Noda Time without loss of information.
+        /// </remarks>
+        /// <param name="duration">The duration to convert. Must not be null.</param>
+        /// <exception cref="ArgumentException"><paramref name="duration"/> represents an invalid duration.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="duration"/> is null.</exception>
+        /// <returns>The Noda Time representation.</returns>
+        public static NodaDuration ToNodaDuration(this ProtobufDuration duration)
+        {
+            Preconditions.CheckNotNull(duration, nameof(duration));
+            long seconds = duration.Seconds;
+            long nanos = duration.Nanos;
+            Preconditions.CheckArgument(
+                seconds >= ProtobufDuration.MinSeconds &&
+                seconds <= ProtobufDuration.MaxSeconds,
+                nameof(duration),
+                "duration.Seconds out of range: {0}",
+                seconds);
+            Preconditions.CheckArgument(
+                nanos > -ProtobufDuration.NanosecondsPerSecond &&
+                nanos < ProtobufDuration.NanosecondsPerSecond,
+                nameof(duration),
+                "duration.Nanos out of range: {0}",
+                nanos);
+            // If either sign is 0, we're fine. Otherwise, they should be the same. Multiplying them
+            // together seems the easiest way to check that.
+            Preconditions.CheckArgument(Math.Sign(seconds) * Math.Sign(nanos) != -1,
+                nameof(duration),
+                "duration.Seconds and duration.Nanos have different signs: {0}s {1}ns",
+                seconds, nanos);
+            return NodaDuration.FromSeconds(seconds) + NodaDuration.FromNanoseconds(nanos);
+        }
+
+        /// <summary>
+        /// Converts a Protobuf <see cref="Timestamp"/> to a Noda Time <see cref="Instant"/>.
+        /// </summary>
+        /// <remarks>
+        /// Every valid Protobuf timestamp can be represented in Noda Time without loss of information.
+        /// </remarks>
+        /// <param name="timestamp">The timestamp to convert. Must not be null.</param>
+        /// <exception cref="ArgumentException"><paramref name="timestamp"/> represents an invalid timestamp.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="timestamp"/> is null.</exception>
+        /// <returns>The Noda Time representation.</returns>
+        public static Instant ToInstant(this Timestamp timestamp)
+        {
+            Preconditions.CheckNotNull(timestamp, nameof(timestamp));
+            long seconds = timestamp.Seconds;
+            long nanos = timestamp.Nanos;
+            Preconditions.CheckArgument(
+                seconds >= MinValidTimestampSeconds &&
+                seconds <= MaxValidTimestampSeconds,
+                nameof(timestamp),
+                "timestamp.Seconds out of range {0}",
+                seconds);
+            Preconditions.CheckArgument(
+                nanos >= 0 &&
+                nanos < ProtobufDuration.NanosecondsPerSecond,
+                nameof(timestamp),
+                "timestamp.Nanos out of range: {0}",
+                nanos);
+            return Instant.FromUnixTimeSeconds(seconds).PlusNanoseconds(nanos);
+        }
+
+        /// <summary>
+        /// Converts a Protobuf <see cref="TimeOfDay"/> to a Noda Time <see cref="LocalTime"/>.
+        /// </summary>
+        /// <param name="timeOfDay">The time of day to convert. Must not be null</param>
+        /// <exception cref="ArgumentException">The time of day is invalid, uses a leap second, or indicates 24:00.</exception>
+        /// <returns>The Noda Time representation.</returns>
+        public static LocalTime ToLocalTime(this TimeOfDay timeOfDay)
+        {
+            Preconditions.CheckNotNull(timeOfDay, nameof(timeOfDay));
+            int hours = timeOfDay.Hours;
+            int minutes = timeOfDay.Minutes;
+            int seconds = timeOfDay.Seconds;
+            int nanos = timeOfDay.Nanos;
+            Preconditions.CheckArgument(hours >= 0 && hours < 24, nameof(timeOfDay),
+                "duration.hours out of range: {0}", hours);
+            Preconditions.CheckArgument(minutes >= 0 && minutes < 60, nameof(timeOfDay),
+                "duration.minutes out of range: {0}", minutes);
+            Preconditions.CheckArgument(seconds >= 0 && seconds < 60, nameof(timeOfDay),
+                "duration.seconds out of range: {0}", seconds);
+            Preconditions.CheckArgument(nanos >= 0 && nanos < NodaConstants.NanosecondsPerSecond, nameof(timeOfDay),
+                "duration.nanos out of range: {0}", nanos);
+            return new LocalTime(hours, minutes, seconds).PlusNanoseconds(nanos);
+        }
+
+        /// <summary>
+        /// Converts a Protobuf <see cref="ProtobufDayOfWeek"/> to a Noda Time <see cref="IsoDayOfWeek"/>.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="ProtobufDayOfWeek.Unspecified"/> value maps to <see cref="IsoDayOfWeek.None"/>.
+        /// </remarks>
+        /// <param name="dayOfWeek">The day-of-week value to convert.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="dayOfWeek"/> is neither Unspecified nor
+        /// a valid day-of-week value.</exception>
+        /// <returns>The Noda Time representation.</returns>
+        public static IsoDayOfWeek ToIsoDayOfWeek(this ProtobufDayOfWeek dayOfWeek)
+        {
+            // Preconditions doesn't have an enum version.
+            if (dayOfWeek < 0 || dayOfWeek > ProtobufDayOfWeek.Sunday)
+            {
+                throw new ArgumentOutOfRangeException(nameof(dayOfWeek), dayOfWeek,
+                    "Only valid day-of-week values (or Unspecified) may be converted");
+            }
+            // Handily, Noda Time and Protobuf use the same numbers.
+            return (IsoDayOfWeek) dayOfWeek;
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
+++ b/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NodaTime.Serialization.JsonNet\NodaTime.Serialization.JsonNet.csproj" />
+    <ProjectReference Include="..\NodaTime.Serialization.Protobuf\NodaTime.Serialization.Protobuf.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,11 +35,58 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <DefineConstants>$(DefineConstants);PCL</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <ItemGroup>
+    <!-- Nesting for tests -->
+    <Compile Update="Protobuf/ProtobufExtensionsTest.*.cs">
+      <DependentUpon>Protobuf/ProtobufExtensionsTest.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf/NodaExtensionsTest.*.cs">
+      <DependentUpon>Protobuf/NodaExtensionsTest.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToTimeOfDay.ToProtobufDayOfWeek.cs">
+      <DependentUpon>NodaExtensionsTest.ToTimeOfDay.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToTimeOfDay.ToProtobufDayOfWeek.ToProtobufDuration.cs">
+      <DependentUpon>NodaExtensionsTest.ToTimeOfDay.ToProtobufDayOfWeek.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToTimeOfDay.ToProtobufDayOfWeek.ToProtobufDuration.ToTimestamp.cs">
+      <DependentUpon>NodaExtensionsTest.ToTimeOfDay.ToProtobufDayOfWeek.ToProtobufDuration.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToTimeOfDay.ToProtobufDayOfWeek.ToTimestamp.cs">
+      <DependentUpon>NodaExtensionsTest.ToTimeOfDay.ToProtobufDayOfWeek.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToTimeOfDay.ToProtobufDuration.cs">
+      <DependentUpon>NodaExtensionsTest.ToTimeOfDay.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToTimeOfDay.ToProtobufDuration.ToTimestamp.cs">
+      <DependentUpon>NodaExtensionsTest.ToTimeOfDay.ToProtobufDuration.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToTimeOfDay.ToTimestamp.cs">
+      <DependentUpon>NodaExtensionsTest.ToTimeOfDay.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToProtobufDayOfWeek.ToProtobufDuration.cs">
+      <DependentUpon>NodaExtensionsTest.ToProtobufDayOfWeek.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToProtobufDayOfWeek.ToProtobufDuration.ToTimestamp.cs">
+      <DependentUpon>NodaExtensionsTest.ToProtobufDayOfWeek.ToProtobufDuration.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToProtobufDayOfWeek.ToTimestamp.cs">
+      <DependentUpon>NodaExtensionsTest.ToProtobufDayOfWeek.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\NodaExtensionsTest.ToProtobufDuration.ToTimestamp.cs">
+      <DependentUpon>NodaExtensionsTest.ToProtobufDuration.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\ProtobufExtensionsTest.ToLocalTime.ToInstant.cs">
+      <DependentUpon>ProtobufExtensionsTest.ToLocalTime.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\ProtobufExtensionsTest.ToLocalTime.ToIsoDayOfWeek.cs">
+      <DependentUpon>ProtobufExtensionsTest.ToLocalTime.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Protobuf\ProtobufExtensionsTest.ToLocalTime.ToNodaDuration.cs">
+      <DependentUpon>ProtobufExtensionsTest.ToLocalTime.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.ToProtobufDayOfWeek.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.ToProtobufDayOfWeek.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NUnit.Framework;
+using System;
+using ProtobufDayOfWeek = Google.Type.DayOfWeek;
+using NodaTime.Serialization.Protobuf;
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class NodaExtensionsTest
+    {
+        // Might as well just list everything...
+        [Test]
+        [TestCase(IsoDayOfWeek.None, ProtobufDayOfWeek.Unspecified)]
+        [TestCase(IsoDayOfWeek.Sunday, ProtobufDayOfWeek.Sunday)]
+        [TestCase(IsoDayOfWeek.Monday, ProtobufDayOfWeek.Monday)]
+        [TestCase(IsoDayOfWeek.Tuesday, ProtobufDayOfWeek.Tuesday)]
+        [TestCase(IsoDayOfWeek.Wednesday, ProtobufDayOfWeek.Wednesday)]
+        [TestCase(IsoDayOfWeek.Thursday, ProtobufDayOfWeek.Thursday)]
+        [TestCase(IsoDayOfWeek.Friday, ProtobufDayOfWeek.Friday)]
+        [TestCase(IsoDayOfWeek.Saturday, ProtobufDayOfWeek.Saturday)]
+        public void Valid(IsoDayOfWeek input, ProtobufDayOfWeek expectedOutput) =>
+            Assert.AreEqual(expectedOutput, input.ToProtobufDayOfWeek());
+
+        [Test]
+        [TestCase((IsoDayOfWeek)(-1))]
+        [TestCase((IsoDayOfWeek)8)]
+        public void OutOfRange(IsoDayOfWeek value) =>
+            Assert.Throws<ArgumentOutOfRangeException>(() => value.ToProtobufDayOfWeek());
+
+    }
+}

--- a/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.ToProtobufDuration.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.ToProtobufDuration.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Serialization.Protobuf;
+using NodaTime.Text;
+using NUnit.Framework;
+using System;
+using ProtoDuration = Google.Protobuf.WellKnownTypes.Duration;
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class NodaExtensionsTest
+    {
+        [Test]
+        [TestCase(ProtoDuration.MinSeconds - 1)]
+        [TestCase(ProtoDuration.MaxSeconds + 1)]
+        public void ToProtobufDuration_OutOfRange(long seconds)
+        {
+            var nodaDuration = Duration.FromSeconds(seconds);
+            Assert.Throws<ArgumentOutOfRangeException>(() => nodaDuration.ToProtobufDuration());
+        }
+
+        [Test]
+        [TestCase("-3652500:00:00:00.999999999", ProtoDuration.MinSeconds, (int)(-NodaConstants.NanosecondsPerSecond) + 1)]
+        [TestCase("3652500:00:00:00.999999999", ProtoDuration.MaxSeconds, (int)(NodaConstants.NanosecondsPerSecond - 1))]
+        [TestCase("0:00:00:00", 0, 0)]
+        [TestCase("-0:00:00:01", -1, 0)]
+        [TestCase("0:00:00:01", 1, 0)]
+        [TestCase("0:00:00:00.000000001", 0, 1)]
+        [TestCase("-0:00:00:00.000000001", 0, -1)]
+        [TestCase("0:00:00:01.5", 1, 500000000)]
+        [TestCase("-0:00:00:01.5", -1, -500000000)]
+        public void ToProtobufDuration_Valid(string nodaDurationText, long expectedSeconds, int expectedNanos)
+        {
+            Duration nodaDuration = DurationPattern.Roundtrip.Parse(nodaDurationText).Value;
+            ProtoDuration protoDuration = nodaDuration.ToProtobufDuration();
+            Assert.AreEqual(expectedSeconds, protoDuration.Seconds);
+            Assert.AreEqual(expectedNanos, protoDuration.Nanos);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.ToTimeOfDay.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.ToTimeOfDay.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Serialization.Protobuf;
+using NodaTime.Text;
+using NUnit.Framework;
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class NodaExtensionsTest
+    {
+        [Test]
+        [TestCase("00:00:00.000000000", 0, 0, 0, 0)]
+        [TestCase("00:00:00.999999999", 0, 0, 0, (int)NodaConstants.NanosecondsPerSecond - 1)]
+        [TestCase("23:59:59.999999999", 23, 59, 59, (int)NodaConstants.NanosecondsPerSecond - 1)]
+        // Just a non-extreme value
+        [TestCase("12:45:23.000500000", 12, 45, 23, 500000)]
+        public void ToTimeOfDay_Valid(string localTimeText, int expectedHours, int expectedMinutes, int expectedSeconds, int expectedNanos)
+        {
+            var pattern = LocalTimePattern.CreateWithInvariantCulture("HH:mm:ss.fffffffff");
+            var localTime = pattern.Parse(localTimeText).Value;
+            var timeOfDay = localTime.ToTimeOfDay();
+            Assert.AreEqual(expectedHours, timeOfDay.Hours);
+            Assert.AreEqual(expectedMinutes, timeOfDay.Minutes);
+            Assert.AreEqual(expectedSeconds, timeOfDay.Seconds);
+            Assert.AreEqual(expectedNanos, timeOfDay.Nanos);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.ToTimestamp.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.ToTimestamp.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Serialization.Protobuf;
+using NodaTime.Text;
+using NUnit.Framework;
+using System;
+using static NodaTime.Serialization.Protobuf.ProtobufExtensions;
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class NodaExtensionsTest
+    {
+        [Test]
+        public void ToTimestamp_OutOfRange()
+        {
+            var instant = NodaConstants.BclEpoch.PlusNanoseconds(-1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => instant.ToTimestamp());
+        }
+
+        [Test]
+        [TestCase("0001-01-01T00:00:00.000000000", MinValidTimestampSeconds, 0)]
+        [TestCase("9999-12-31T23:59:59.999999999", MaxValidTimestampSeconds, (int)(NodaConstants.NanosecondsPerSecond - 1))]
+        [TestCase("1970-01-01T00:00:00.000000000", 0, 0)]
+        [TestCase("1970-01-01T00:00:00.000000001", 0, 1)]
+        [TestCase("1970-01-01T00:00:01.000000000", 1, 0)]
+        [TestCase("1969-12-31T23:59:59.000000000", -1, 0)]
+        [TestCase("2017-07-24T09:37:05.123456789", 1500889025, 123456789)]
+        public void ToTimestamp_Valid(string instantText, long expectedSeconds, int expectedNanos)
+        {
+            var pattern = InstantPattern.CreateWithInvariantCulture("uuuu-MM-dd'T'HH:mm:ss.fffffffff");
+            var instant = pattern.Parse(instantText).Value;
+            var timestamp = instant.ToTimestamp();
+            Assert.AreEqual(expectedSeconds, timestamp.Seconds);
+            Assert.AreEqual(expectedNanos, timestamp.Nanos);
+        }
+
+    }
+}

--- a/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/NodaExtensionsTest.cs
@@ -1,0 +1,10 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class NodaExtensionsTest
+    {
+    }
+}

--- a/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.ToInstant.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.ToInstant.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Google.Protobuf.WellKnownTypes;
+using NodaTime.Serialization.Protobuf;
+using NodaTime.Text;
+using NUnit.Framework;
+using System;
+using static NodaTime.Serialization.Protobuf.ProtobufExtensions;
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class ProtobufExtensionsTest
+    {
+        // Bounds are from https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto
+
+        [Test]
+        [TestCase(0, (int) NodaConstants.NanosecondsPerSecond, Description = "Nanos out of range")]
+        [TestCase(0, -1, Description = "Nanos out of range")]
+        [TestCase(MinValidTimestampSeconds - 1, 0, Description = "Seconds out of range")]
+        [TestCase(MaxValidTimestampSeconds + 1, 0, Description = "Seconds out of range")]
+        public void ToInstant_InvalidTimestamp(long seconds, int nanos)
+        {
+            var timestamp = new Timestamp { Seconds = seconds, Nanos = nanos };
+            Assert.Throws<ArgumentException>(() => timestamp.ToInstant());
+        }
+        
+        [Test]
+        [TestCase(MinValidTimestampSeconds, 0, "0001-01-01T00:00:00.000000000")]
+        [TestCase(MaxValidTimestampSeconds, (int) (NodaConstants.NanosecondsPerSecond - 1), "9999-12-31T23:59:59.999999999")]
+        [TestCase(0, 0, "1970-01-01T00:00:00.000000000")]
+        [TestCase(0, 1, "1970-01-01T00:00:00.000000001")]
+        [TestCase(1, 0, "1970-01-01T00:00:01.000000000")]
+        [TestCase(-1, 0, "1969-12-31T23:59:59.000000000")]
+        [TestCase(1500889025, 123456789, "2017-07-24T09:37:05.123456789")]
+        public void ToInstant_Valid(long seconds, int nanos, string expectedResult)
+        {
+            var pattern = InstantPattern.CreateWithInvariantCulture("uuuu-MM-dd'T'HH:mm:ss.fffffffff");
+            var timestamp = new Timestamp { Seconds = seconds, Nanos = nanos };
+            var instant = timestamp.ToInstant();
+            Assert.AreEqual(expectedResult, pattern.Format(instant));
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.ToIsoDayOfWeek.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.ToIsoDayOfWeek.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Serialization.Protobuf;
+using NUnit.Framework;
+using System;
+
+using ProtoDayOfWeek = Google.Type.DayOfWeek;
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class ProtobufExtensionsTest
+    {
+        // Might as well just list everything...
+        [Test]
+        [TestCase(ProtoDayOfWeek.Unspecified, IsoDayOfWeek.None)]
+        [TestCase(ProtoDayOfWeek.Sunday, IsoDayOfWeek.Sunday)]
+        [TestCase(ProtoDayOfWeek.Monday, IsoDayOfWeek.Monday)]
+        [TestCase(ProtoDayOfWeek.Tuesday, IsoDayOfWeek.Tuesday)]
+        [TestCase(ProtoDayOfWeek.Wednesday, IsoDayOfWeek.Wednesday)]
+        [TestCase(ProtoDayOfWeek.Thursday, IsoDayOfWeek.Thursday)]
+        [TestCase(ProtoDayOfWeek.Friday, IsoDayOfWeek.Friday)]
+        [TestCase(ProtoDayOfWeek.Saturday, IsoDayOfWeek.Saturday)]
+        public void Valid(ProtoDayOfWeek input, IsoDayOfWeek expectedOutput) =>
+            Assert.AreEqual(expectedOutput, input.ToIsoDayOfWeek());
+
+        [Test]
+        [TestCase((ProtoDayOfWeek) (-1))]
+        [TestCase((ProtoDayOfWeek) 8)]
+        public void OutOfRange(ProtoDayOfWeek value) =>
+            Assert.Throws<ArgumentOutOfRangeException>(() => value.ToIsoDayOfWeek());
+    }
+}

--- a/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.ToLocalTime.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.ToLocalTime.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Google.Type;
+using NodaTime.Serialization.Protobuf;
+using NodaTime.Text;
+using NUnit.Framework;
+using System;
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class ProtobufExtensionsTest
+    {
+        /// <summary>
+        /// These are times of day which are invalid in Protobuf.
+        /// </summary>
+        [Test]
+        [TestCase(-1, 0, 0, 0)]
+        [TestCase(25, 0, 0, 0)] // 24 is handled below
+        [TestCase(0, -1, 0, 0)]
+        [TestCase(0, 60, 0, 0)]
+        [TestCase(0, 0, -1, 0)]
+        [TestCase(0, 0, 61, 0)] // 60 is handled below
+        [TestCase(0, 0, 0, -1)]
+        [TestCase(0, 0, 0, (int) NodaConstants.NanosecondsPerSecond)]
+        public void ToLocalTime_InvalidTimeOfDay(int hours, int minutes, int seconds, int nanos)
+        {
+            var timeOfDay = new TimeOfDay { Hours = hours, Minutes = minutes, Seconds = seconds, Nanos = nanos };
+            Assert.Throws<ArgumentException>(() => timeOfDay.ToLocalTime());
+        }
+
+        /// <summary>
+        /// These are times of day which are valid in Protobuf,
+        /// but not supported by Noda Time.
+        /// </summary>
+        [Test]
+        [TestCase(25, 0, 0, 0, Description = "End of day, 24:00")]
+        [TestCase(0, 0, 60, 0, Description = "Leap second")]
+        public void ToLocalTime_UnhandledTimeOfDay(int hours, int minutes, int seconds, int nanos)
+        {
+            var timeOfDay = new TimeOfDay { Hours = hours, Minutes = minutes, Seconds = seconds, Nanos = nanos };
+            Assert.Throws<ArgumentException>(() => timeOfDay.ToLocalTime());
+        }
+
+        [Test]
+        [TestCase(0, 0, 0, 0, "00:00:00.000000000")]
+        [TestCase(0, 0, 0, (int) NodaConstants.NanosecondsPerSecond - 1, "00:00:00.999999999")]
+        [TestCase(23, 59, 59, (int)NodaConstants.NanosecondsPerSecond - 1, "23:59:59.999999999")]
+        // Just a non-extreme value
+        [TestCase(12, 45, 23, 500000, "12:45:23.000500000")]
+        public void ToLocalTime_Valid(int hours, int minutes, int seconds, int nanos, string expectedResult)
+        {
+            var pattern = LocalTimePattern.CreateWithInvariantCulture("HH:mm:ss.fffffffff");
+            var timeOfDay = new TimeOfDay { Hours = hours, Minutes = minutes, Seconds = seconds, Nanos = nanos };
+            var localTime = timeOfDay.ToLocalTime();
+            Assert.AreEqual(expectedResult, pattern.Format(localTime));
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.ToNodaDuration.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.ToNodaDuration.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Serialization.Protobuf;
+using NodaTime.Text;
+using NUnit.Framework;
+using System;
+using ProtoDuration = Google.Protobuf.WellKnownTypes.Duration;
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class ProtobufExtensionsTest
+    {
+        // Bounds are from https://github.com/google/protobuf/blob/master/src/google/protobuf/duration.proto
+
+        [Test]
+        [TestCase(ProtoDuration.MinSeconds - 1, 0)]
+        [TestCase(ProtoDuration.MaxSeconds + 1, 0)]
+        [TestCase(0, (int) (-NodaConstants.NanosecondsPerSecond))]
+        [TestCase(0, (int) NodaConstants.NanosecondsPerSecond)]
+        [TestCase(-1, 1, Description = "Different sign")]
+        [TestCase(1, -1, Description = "Different sign")]
+        public void ToNodaDuration_Invalid(long seconds, int nanos)
+        {
+            var input = new ProtoDuration { Seconds = seconds, Nanos = nanos };
+            Assert.Throws<ArgumentException>(() => input.ToNodaDuration());
+        }
+
+        [TestCase(ProtoDuration.MinSeconds, (int)(-NodaConstants.NanosecondsPerSecond) + 1, "-3652500:00:00:00.999999999")]
+        [TestCase(ProtoDuration.MaxSeconds, (int) (NodaConstants.NanosecondsPerSecond - 1), "3652500:00:00:00.999999999")]
+        [TestCase(0, 0, "0:00:00:00")]
+        [TestCase(-1, 0, "-0:00:00:01")]
+        [TestCase(1, 0, "0:00:00:01")]
+        [TestCase(0, 1, "0:00:00:00.000000001")]
+        [TestCase(0, -1, "-0:00:00:00.000000001")]
+        [TestCase(1, 500000000, "0:00:00:01.5")]
+        [TestCase(-1, -500000000, "-0:00:00:01.5")]
+        public void ToNodaDuration_Valid(long seconds, int nanos, string expectedResult)
+        {
+            var input = new ProtoDuration { Seconds = seconds, Nanos = nanos };
+            var nodaDuration = input.ToNodaDuration();
+            Assert.AreEqual(expectedResult, DurationPattern.Roundtrip.Format(nodaDuration));
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.cs
+++ b/src/NodaTime.Serialization.Test/Protobuf/ProtobufExtensionsTest.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NUnit.Framework;
+using static NodaTime.Serialization.Protobuf.ProtobufExtensions;
+
+namespace NodaTime.Serialization.Test.Protobuf
+{
+    public partial class ProtobufExtensionsTest
+    {
+        [Test]
+        public void MinMaxValidTimestampSeconds()
+        {
+            // These are useful to have as compile-time constants, but let's validate them.
+            Assert.AreEqual(MinValidTimestampSeconds, Instant.FromUtc(1, 1, 1, 0, 0).ToUnixTimeSeconds());
+            Assert.AreEqual(MaxValidTimestampSeconds, Instant.FromUtc(9999, 12, 31, 23, 59, 59).ToUnixTimeSeconds());
+        }
+    }
+}

--- a/src/NodaTime.Serialization.sln
+++ b/src/NodaTime.Serialization.sln
@@ -1,32 +1,73 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaTime.Serialization.Test", "NodaTime.Serialization.Test\NodaTime.Serialization.Test.csproj", "{07063FD8-A2C2-43FB-A52C-093F4FB3F483}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaTime.Serialization.JsonNet", "NodaTime.Serialization.JsonNet\NodaTime.Serialization.JsonNet.csproj", "{40445ECC-0F53-4ED2-A764-C6F81410DF73}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NodaTime.Serialization.Benchmarks", "NodaTime.Serialization.Benchmarks\NodaTime.Serialization.Benchmarks.csproj", "{7E96596E-800E-4F71-9304-F1D0F6B9937B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaTime.Serialization.Benchmarks", "NodaTime.Serialization.Benchmarks\NodaTime.Serialization.Benchmarks.csproj", "{7E96596E-800E-4F71-9304-F1D0F6B9937B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaTime.Serialization.Protobuf", "NodaTime.Serialization.Protobuf\NodaTime.Serialization.Protobuf.csproj", "{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Debug|x64.Build.0 = Debug|Any CPU
+		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Debug|x86.Build.0 = Debug|Any CPU
 		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Release|x64.ActiveCfg = Release|Any CPU
+		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Release|x64.Build.0 = Release|Any CPU
+		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Release|x86.ActiveCfg = Release|Any CPU
+		{07063FD8-A2C2-43FB-A52C-093F4FB3F483}.Release|x86.Build.0 = Release|Any CPU
 		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Debug|x64.Build.0 = Debug|Any CPU
+		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Debug|x86.Build.0 = Debug|Any CPU
 		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Release|x64.ActiveCfg = Release|Any CPU
+		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Release|x64.Build.0 = Release|Any CPU
+		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Release|x86.ActiveCfg = Release|Any CPU
+		{40445ECC-0F53-4ED2-A764-C6F81410DF73}.Release|x86.Build.0 = Release|Any CPU
 		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Debug|x86.Build.0 = Debug|Any CPU
 		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Release|x64.Build.0 = Release|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E96596E-800E-4F71-9304-F1D0F6B9937B}.Release|x86.Build.0 = Release|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Debug|x64.Build.0 = Debug|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Debug|x86.Build.0 = Debug|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Release|x64.ActiveCfg = Release|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Release|x64.Build.0 = Release|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Release|x86.ActiveCfg = Release|Any CPU
+		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
(First two commits are pre-protobuf work, but might as well be reviewed in the same PR...)

I've gone for v1.0.0 for the protobuf project rather than 2.0.0, as it's not tied to the Noda Time versioning anyway. (It could go to 3.5 before Noda Time gets to 3.0 for example. I don't expect it to, but...)
