### PR TITLE
Add DateIntervalConverter/IsoDateIntervalConverter converters

### DIFF
--- a/src/NodaTime.Serialization.JsonNet/Extensions.cs
+++ b/src/NodaTime.Serialization.JsonNet/Extensions.cs
@@ -97,6 +97,38 @@ namespace NodaTime.Serialization.JsonNet
             return serializer;
         }
 
+        /// <summary>
+        /// Configures the given serializer settings to use <see cref="NodaConverters.IsoDateIntervalConverter"/>.
+        /// Any other converters which can convert <see cref="DateInterval"/> are removed from the serializer.
+        /// </summary>
+        /// <param name="settings">The existing serializer settings to add Noda Time converters to.</param>
+        /// <returns>The original <paramref name="settings"/> value, for further chaining.</returns>
+        public static JsonSerializerSettings WithIsoDateIntervalConverter(this JsonSerializerSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            ReplaceExistingConverters<DateInterval>(settings.Converters, NodaConverters.IsoDateIntervalConverter);
+            return settings;
+        }
+
+        /// <summary>
+        /// Configures the given serializer to use <see cref="NodaConverters.IsoDateIntervalConverter"/>.
+        /// Any other converters which can convert <see cref="DateInterval"/> are removed from the serializer.
+        /// </summary>
+        /// <param name="serializer">The existing serializer to add Noda Time converters to.</param>
+        /// <returns>The original <paramref name="serializer"/> value, for further chaining.</returns>
+        public static JsonSerializer WithIsoDateIntervalConverter(this JsonSerializer serializer)
+        {
+            if (serializer == null)
+            {
+                throw new ArgumentNullException(nameof(serializer));
+            }
+            ReplaceExistingConverters<DateInterval>(serializer.Converters, NodaConverters.IsoDateIntervalConverter);
+            return serializer;
+        }
+
         private static void AddDefaultConverters(IList<JsonConverter> converters, IDateTimeZoneProvider provider)
         {
             converters.Add(NodaConverters.InstantConverter);
@@ -104,6 +136,7 @@ namespace NodaTime.Serialization.JsonNet
             converters.Add(NodaConverters.LocalDateConverter);
             converters.Add(NodaConverters.LocalDateTimeConverter);
             converters.Add(NodaConverters.LocalTimeConverter);
+            converters.Add(NodaConverters.DateIntervalConverter);
             converters.Add(NodaConverters.OffsetConverter);
             converters.Add(NodaConverters.CreateDateTimeZoneConverter(provider));
             converters.Add(NodaConverters.DurationConverter);

--- a/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
@@ -54,6 +54,17 @@ namespace NodaTime.Serialization.JsonNet
             = new NodaIsoIntervalConverter();
 
         /// <summary>
+        /// Converter for date intervals. This must be used in a serializer which also has a local date converter.
+        /// </summary>
+        public static JsonConverter DateIntervalConverter { get; } = new NodaDateIntervalConverter();
+
+        /// <summary>
+        /// Converter for date intervals using ISO-8601 format, as defined by <see cref="LocalDatePattern.Iso"/>.
+        /// </summary>
+        public static JsonConverter IsoDateIntervalConverter { get; }
+            = new NodaIsoDateIntervalConverter();
+
+        /// <summary>
         /// Converter for offsets.
         /// </summary>
         public static JsonConverter OffsetConverter { get; }

--- a/src/NodaTime.Serialization.JsonNet/NodaDateIntervalConverter.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaDateIntervalConverter.cs
@@ -1,0 +1,84 @@
+// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Newtonsoft.Json;
+using NodaTime.Utility;
+
+namespace NodaTime.Serialization.JsonNet
+{
+    /// <summary>
+    /// Json.NET converter for <see cref="DateInterval"/> using a compound representation. The start and
+    /// end aspects of the date interval are represented with separate properties, each parsed and formatted
+    /// by the <see cref="DateInstant"/> converter for the serializer provided.
+    /// </summary>   
+    internal sealed class NodaDateIntervalConverter : NodaConverterBase<DateInterval>
+    {
+        /// <summary>
+        /// Reads Start and End properties for the start and end of a date interval, converting them to local dates
+        /// using the given serializer.
+        /// </summary>
+        /// <param name="reader">The JSON reader to fetch data from.</param>
+        /// <param name="serializer">The serializer for embedded serialization.</param>
+        /// <returns>The <see cref="DateInterval"/> identified in the JSON.</returns>
+        protected override DateInterval ReadJsonImpl(JsonReader reader, JsonSerializer serializer)
+        {
+            LocalDate? startLocalDate = null;
+            LocalDate? endLocalDate = null;
+            while (reader.Read())
+            {
+                if (reader.TokenType != JsonToken.PropertyName)
+                {
+                    break;
+                }
+
+                var propertyName = (string)reader.Value;
+                if (!reader.Read())
+                {
+                    break;
+                }
+
+                if (propertyName == "Start")
+                {
+                    startLocalDate = serializer.Deserialize<LocalDate>(reader);
+                }
+
+                if (propertyName == "End")
+                {
+                    endLocalDate = serializer.Deserialize<LocalDate>(reader);
+                }
+            }
+
+            if (!startLocalDate.HasValue)
+            {
+                throw new InvalidNodaDataException("Expected date interval; start date was missing.");
+            }
+
+            if (!endLocalDate.HasValue)
+            {
+                throw new InvalidNodaDataException("Expected date interval; end date was missing.");
+            }
+
+            return new DateInterval(startLocalDate.Value, endLocalDate.Value);
+        }
+
+        /// <summary>
+        /// Serializes the date interval as start/end local dates.
+        /// </summary>
+        /// <param name="writer">The writer to write JSON to</param>
+        /// <param name="value">The date interval to serialize</param>
+        /// <param name="serializer">The serializer for embedded serialization.</param>
+        protected override void WriteJsonImpl(JsonWriter writer, DateInterval value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+
+            writer.WritePropertyName("Start");
+            serializer.Serialize(writer, value.Start);
+
+            writer.WritePropertyName("End");
+            serializer.Serialize(writer, value.End);
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/NodaTime.Serialization.JsonNet/NodaIsoDateIntervalConverter.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaIsoDateIntervalConverter.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Newtonsoft.Json;
+using NodaTime.Text;
+using NodaTime.Utility;
+
+namespace NodaTime.Serialization.JsonNet
+{
+    /// <summary>
+    /// Json.NET converter for <see cref="DateInterval"/>.
+    /// </summary>   
+    internal sealed class NodaIsoDateIntervalConverter : NodaConverterBase<DateInterval>
+    {
+        protected override DateInterval ReadJsonImpl(JsonReader reader, JsonSerializer serializer)
+        {
+            if (reader.TokenType != JsonToken.String)
+            {
+                throw new InvalidNodaDataException(
+                    $"Unexpected token parsing DateInterval. Expected String, got {reader.TokenType}.");
+            }
+            string text = reader.Value.ToString();
+            int slash = text.IndexOf('/');
+            if (slash == -1)
+            {
+                throw new InvalidNodaDataException("Expected ISO-8601-formatted date interval; slash was missing.");
+            }
+
+            string startText = text.Substring(0, slash);
+            if (startText == "")
+            {
+                throw new InvalidNodaDataException("Expected ISO-8601-formatted date interval; start date was missing.");
+            }
+
+            string endText = text.Substring(slash + 1);
+            if (endText == "")
+            {
+                throw new InvalidNodaDataException("Expected ISO-8601-formatted date interval; end date was missing.");
+            }
+            
+            var pattern = LocalDatePattern.Iso;
+            var start = pattern.Parse(startText).Value;
+            var end = pattern.Parse(endText).Value;
+
+            return new DateInterval(start, end);
+        }
+
+        /// <summary>
+        /// Serializes the date interval as start/end instants.
+        /// </summary>
+        /// <param name="writer">The writer to write JSON to</param>
+        /// <param name="value">The date interval to serialize</param>
+        /// <param name="serializer">The serializer for embedded serialization.</param>
+        protected override void WriteJsonImpl(JsonWriter writer, DateInterval value, JsonSerializer serializer)
+        {
+            var pattern = LocalDatePattern.Iso;
+            string text = pattern.Format(value.Start) + "/" + pattern.Format(value.End);
+            writer.WriteValue(text);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/JsonNet/ExtensionsTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/ExtensionsTest.cs
@@ -56,6 +56,52 @@ namespace NodaTime.Serialization.Test.JsonNet
                 JsonConvert.SerializeObject(interval, configuredSettings));
         }
 
+        [Test]
+        public void Serializer_ConfigureForNodaTime_DefaultDateInterval()
+        {
+            var configuredSerializer = new JsonSerializer().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+            var explicitSerializer = new JsonSerializer
+            {
+                Converters = { NodaConverters.DateIntervalConverter, NodaConverters.LocalDateConverter }
+            };
+            var interval = new DateInterval(new LocalDate(2001, 2, 3), new LocalDate(2004, 5, 6));
+            Assert.AreEqual(Serialize(interval, explicitSerializer),
+                Serialize(interval, configuredSerializer));
+        }
+
+        [Test]
+        public void Serializer_ConfigureForNodaTime_WithIsoDateIntervalConverter()
+        {
+            var configuredSerializer = new JsonSerializer().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb).WithIsoDateIntervalConverter();
+            var explicitSerializer = new JsonSerializer { Converters = { NodaConverters.IsoDateIntervalConverter } };
+            var interval = new DateInterval(new LocalDate(2001, 2, 3), new LocalDate(2004, 5, 6));
+            Assert.AreEqual(Serialize(interval, explicitSerializer),
+                Serialize(interval, configuredSerializer));
+        }
+
+        [Test]
+        public void Settings_ConfigureForNodaTime_DefaultDateInterval()
+        {
+            var configuredSettings = new JsonSerializerSettings().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+            var explicitSettings = new JsonSerializerSettings
+            {
+                Converters = { NodaConverters.DateIntervalConverter, NodaConverters.LocalDateConverter }
+            };
+            var interval = new DateInterval(new LocalDate(2001, 2, 3), new LocalDate(2004, 5, 6));
+            Assert.AreEqual(JsonConvert.SerializeObject(interval, explicitSettings),
+                JsonConvert.SerializeObject(interval, configuredSettings));
+        }
+
+        [Test]
+        public void Settings_ConfigureForNodaTime_WithIsoDateIntervalConverter()
+        {
+            var configuredSettings = new JsonSerializerSettings().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb).WithIsoDateIntervalConverter();
+            var explicitSettings = new JsonSerializerSettings { Converters = { NodaConverters.IsoDateIntervalConverter } };
+            var interval = new DateInterval(new LocalDate(2001, 2, 3), new LocalDate(2004, 5, 6));
+            Assert.AreEqual(JsonConvert.SerializeObject(interval, explicitSettings),
+                JsonConvert.SerializeObject(interval, configuredSettings));
+        }
+
         private static string Serialize<T>(T value, JsonSerializer serializer)
         {
             var writer = new StringWriter();

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaDateIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaDateIntervalConverterTest.cs
@@ -1,0 +1,65 @@
+// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+
+using Newtonsoft.Json;
+using NodaTime.Serialization.JsonNet;
+using NUnit.Framework;
+
+namespace NodaTime.Serialization.Test.JsonNet
+{
+    public class NodaDateIntervalConverterTest
+    {
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        {
+            Converters = { NodaConverters.DateIntervalConverter, NodaConverters.LocalDateConverter },
+            DateParseHandling = DateParseHandling.None
+        };
+
+        [Test]
+        public void RoundTrip()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+            AssertConversions(dateInterval, "{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}", settings);
+        }
+
+        [Test]
+        public void Serialize_InObject()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+
+            var testObject = new TestObject { Interval = dateInterval };
+
+            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+
+            string expectedJson = "{\"Interval\":{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Deserialize_InObject()
+        {
+            string json = "{\"Interval\":{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}}";
+
+            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+
+            var interval = testObject.Interval;
+
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var expectedInterval = new DateInterval(startLocalDate, endLocalDate);
+            Assert.AreEqual(expectedInterval, interval);
+        }
+
+        public class TestObject
+        {
+            public DateInterval Interval { get; set; }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaIsoDateIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaIsoDateIntervalConverterTest.cs
@@ -1,0 +1,75 @@
+// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+
+using Newtonsoft.Json;
+using NodaTime.Serialization.JsonNet;
+using NUnit.Framework;
+
+namespace NodaTime.Serialization.Test.JsonNet
+{
+    /// <summary>
+    /// The same tests as NodaDateIntervalConverterTest, but using the ISO-based interval converter.
+    /// </summary>
+    public class NodaIsoDateIntervalConverterTest
+    {
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        {
+            Converters = { NodaConverters.IsoDateIntervalConverter, NodaConverters.LocalDateConverter },
+            DateParseHandling = DateParseHandling.None
+        };
+
+        [Test]
+        public void RoundTrip()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+            AssertConversions(dateInterval, "\"2012-01-02/2013-06-07\"", settings);
+        }
+
+        [Test]
+        [TestCase("\"2012-01-022013-06-07\"")]
+        public void InvalidJson(string json)
+        {
+            AssertInvalidJson<DateInterval>(json, settings);
+        }
+
+        [Test]
+        public void Serialize_InObject()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+
+            var testObject = new TestObject { Interval = dateInterval };
+
+            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+
+            string expectedJson = "{\"Interval\":\"2012-01-02/2013-06-07\"}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Deserialize_InObject()
+        {
+            string json = "{\"Interval\":\"2012-01-02/2013-06-07\"}";
+
+            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+
+            var interval = testObject.Interval;
+
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var expectedInterval = new DateInterval(startLocalDate, endLocalDate);
+            Assert.AreEqual(expectedInterval, interval);
+        }
+
+        public class TestObject
+        {
+            public DateInterval Interval { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
These are basically modified copies of `NodaIntervalConverter` and `NodaIsoIntervalConverter` with the difference that they convert from/to `DateInterval`. As the `DateInterval` does not allow start or end to be null, this does not support the `infinte` syntax as the originals do.