### PR TITLE
throw a derived JsonSerializationException when the reading fails

### DIFF
--- a/src/NodaTime.Serialization.JsonNet/NodaConverterBase.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaConverterBase.cs
@@ -71,12 +71,19 @@ namespace NodaTime.Serialization.JsonNet
                 }
             }
 
-            // Delegate to the concrete subclass. At this point we know that we don't want to return null, so we
-            // can ask the subclass to return a T, which we will box. That will be valid even if objectType is
-            // T? because the boxed form of a non-null T? value is just the boxed value itself.
+            try
+            {
+                // Delegate to the concrete subclass. At this point we know that we don't want to return null, so we
+                // can ask the subclass to return a T, which we will box. That will be valid even if objectType is
+                // T? because the boxed form of a non-null T? value is just the boxed value itself.
 
-            // Note that we don't currently pass existingValue down; we could change this if we ever found a use for it.
-            return ReadJsonImpl(reader, serializer);
+                // Note that we don't currently pass existingValue down; we could change this if we ever found a use for it.
+                return ReadJsonImpl(reader, serializer);
+            }
+            catch (Exception ex)
+            {
+                throw new JsonSerializationException($"Cannot convert value to {objectType}", ex);
+            }
         }
 
         /// <summary>

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaDateTimeZoneConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaDateTimeZoneConverterTest.cs
@@ -35,7 +35,8 @@ namespace NodaTime.Serialization.Test.JsonNet
         public void Deserialize_TimeZoneNotFound()
         {
             string json = "\"America/DOES_NOT_EXIST\"";
-            Assert.Throws<DateTimeZoneNotFoundException>(() => JsonConvert.DeserializeObject<DateTimeZone>(json, converter));
+            var exception = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DateTimeZone>(json, converter));
+            Assert.IsInstanceOf<DateTimeZoneNotFoundException>(exception.InnerException);
         }
     }
 }

--- a/src/NodaTime.Serialization.Test/JsonNet/TestHelper.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/TestHelper.cs
@@ -31,7 +31,8 @@ namespace NodaTime.Serialization.Test.JsonNet
 
         internal static void AssertInvalidJson<T>(string json, JsonSerializerSettings settings)
         {
-            Assert.Throws<InvalidNodaDataException>(() => JsonConvert.DeserializeObject<T>(json, settings));
+            var exception = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<T>(json, settings));
+            Assert.IsInstanceOf<InvalidNodaDataException>(exception.InnerException);
         }
     }
 }


### PR DESCRIPTION
this should enable ASP.NET Core to generate 400s when the reading
of the JSON fails.

fixes #32 