### PR TITLE
Use the right output directory

### DIFF
--- a/build/buildrelease.sh
+++ b/build/buildrelease.sh
@@ -34,4 +34,4 @@ dotnet test -c Release src/NodaTime.Serialization.Test/NodaTime.Serialization.Te
 
 mkdir $OUTPUT
 
-dotnet pack --no-build -c Release src/NodaTime.Serialization.sln -o $OUTPUT
+dotnet pack --no-build -c Release src/NodaTime.Serialization.sln -o $PWD/OUTPUT


### PR DESCRIPTION
By default, dotnet build treats the output directory as relative