### PR TITLE
Added: System.Text.Json serialization support

### DIFF
--- a/src/NodaTime.Serialization.SystemText/DelegatingConverterBase.cs
+++ b/src/NodaTime.Serialization.SystemText/DelegatingConverterBase.cs
@@ -1,0 +1,65 @@
+﻿// Copyright 2019 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NodaTime.Serialization.SystemText
+{
+    /// <summary>
+    /// Converter which does nothing but delegate to another one for all operations.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in this class is specific to Noda Time. Its purpose is to make it easy
+    /// to reuse other converter instances with <see cref="LocalDate"/>,
+    /// which can only identify a converter by type.
+    /// </remarks>
+    /// <example>
+    /// <para>
+    /// If you had some <see cref="JsonConverterAttribute"/> properties which needed one converter,
+    /// but others that needed another, you might want to have different types implementing
+    /// those converters. Each type would just derive from this, passing the right converter
+    /// into the base constructor.
+    /// </para>
+    /// <code>
+    /// public sealed class ShortDateConverter : DelegatingConverterBase
+    /// {
+    ///     public ShortDateConverter() : base(NodaConverters.LocalDateConverter) {}
+    /// }
+    /// </code>
+    /// </example>
+    public abstract class DelegatingConverterBase<T> : JsonConverter<T>
+    {
+        private readonly JsonConverter<T> original;
+
+        /// <summary>
+        /// Constructs a converter delegating to <paramref name="original"/>.
+        /// </summary>
+        /// <param name="original">The converter to delegate to. Must not be null.</param>
+        protected DelegatingConverterBase(JsonConverter<T> original)
+        {
+            if (original == null)
+            {
+                throw new ArgumentNullException(nameof(original));
+            }
+            this.original = original;
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            original.Write(writer, value, options);
+        }
+
+        /// <inheritdoc />
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return original.Read(ref reader, typeToConvert, options);
+        }
+
+        /// <inheritdoc />
+        public override bool CanConvert(Type objectType) => original.CanConvert(objectType);
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/Extensions.cs
+++ b/src/NodaTime.Serialization.SystemText/Extensions.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NodaTime.Serialization.SystemText
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// Resolves property name according <see cref="DefaultContractResolver.NamingStrategy"/>.
+        /// <para>If serializer is not <see cref="DefaultContractResolver"/> then original <paramref name="propertyName"/> returns.</para>
+        /// </summary>
+        /// <param name="serializerOptions">The serializer options to use name resolve.</param>
+        /// <param name="propertyName">Property name.</param>
+        /// <returns>Resolved or original property name.</returns>
+        internal static string ResolvePropertyName(this JsonSerializerOptions serializerOptions, string propertyName) =>
+            (serializerOptions.PropertyNamingPolicy)?.ConvertName(propertyName) ?? propertyName;
+
+        internal static T ReadType<T>(this JsonSerializerOptions serializerOptions, ref Utf8JsonReader reader)
+        {
+            var converter = (JsonConverter<T>)serializerOptions.GetConverter(typeof(T));
+            return converter.Read(ref reader, typeof(T), serializerOptions);
+        }
+
+        internal static void WriteType<T>(this JsonSerializerOptions serializerOptions, Utf8JsonWriter writer, T value)
+        {
+            var converter = (JsonConverter<T>)serializerOptions.GetConverter(typeof(T));
+            converter.Write(writer, value, serializerOptions);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/Extensions.cs
+++ b/src/NodaTime.Serialization.SystemText/Extensions.cs
@@ -1,13 +1,107 @@
+// Copyright 2019 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace NodaTime.Serialization.SystemText
 {
+    /// <summary>
+    /// Static class containing extension methods to configure System.Text.Json for Noda Time types.
+    /// </summary>
     public static class Extensions
     {
         /// <summary>
-        /// Resolves property name according <see cref="DefaultContractResolver.NamingStrategy"/>.
-        /// <para>If serializer is not <see cref="DefaultContractResolver"/> then original <paramref name="propertyName"/> returns.</para>
+        /// Configures System.Text.Json with everything required to properly serialize and deserialize NodaTime data types.
+        /// </summary>
+        /// <param name="options">The existing options to add Noda Time converters to.</param>
+        /// <param name="provider">The time zone provider to use when parsing time zones and zoned date/times.</param>
+        /// <returns>The original <paramref name="options"/> value, for further chaining.</returns>
+        public static JsonSerializerOptions ConfigureForNodaTime(this JsonSerializerOptions options, IDateTimeZoneProvider provider)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+            // Add our converters
+            AddDefaultConverters(options.Converters, provider);
+
+            // return to allow fluent chaining if desired
+            return options;
+        }
+
+        /// <summary>
+        /// Configures the given serializer settings to use <see cref="NodaConverters.IsoIntervalConverter"/>.
+        /// Any other converters which can convert <see cref="Interval"/> are removed from the serializer.
+        /// </summary>
+        /// <param name="options">The existing serializer settings to add Noda Time converters to.</param>
+        /// <returns>The original <paramref name="options"/> value, for further chaining.</returns>
+        public static JsonSerializerOptions WithIsoIntervalConverter(this JsonSerializerOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            ReplaceExistingConverters<Interval>(options.Converters, NodaConverters.IsoIntervalConverter);
+            return options;
+        }
+
+        /// <summary>
+        /// Configures the given serializer settings to use <see cref="NodaConverters.IsoDateIntervalConverter"/>.
+        /// Any other converters which can convert <see cref="DateInterval"/> are removed from the serializer.
+        /// </summary>
+        /// <param name="options">The existing serializer settings to add Noda Time converters to.</param>
+        /// <returns>The original <paramref name="options"/> value, for further chaining.</returns>
+        public static JsonSerializerOptions WithIsoDateIntervalConverter(this JsonSerializerOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            ReplaceExistingConverters<DateInterval>(options.Converters, NodaConverters.IsoDateIntervalConverter);
+            return options;
+        }
+
+        private static void AddDefaultConverters(IList<JsonConverter> converters, IDateTimeZoneProvider provider)
+        {
+            converters.Add(NodaConverters.InstantConverter);
+            converters.Add(NodaConverters.IntervalConverter);
+            converters.Add(NodaConverters.LocalDateConverter);
+            converters.Add(NodaConverters.LocalDateTimeConverter);
+            converters.Add(NodaConverters.LocalTimeConverter);
+            converters.Add(NodaConverters.DateIntervalConverter);
+            converters.Add(NodaConverters.OffsetConverter);
+            converters.Add(NodaConverters.CreateDateTimeZoneConverter(provider));
+            converters.Add(NodaConverters.DurationConverter);
+            converters.Add(NodaConverters.RoundtripPeriodConverter);
+            converters.Add(NodaConverters.OffsetDateTimeConverter);
+            converters.Add(NodaConverters.OffsetDateConverter);
+            converters.Add(NodaConverters.OffsetTimeConverter);
+            converters.Add(NodaConverters.CreateZonedDateTimeConverter(provider));
+        }
+
+        private static void ReplaceExistingConverters<T>(IList<JsonConverter> converters, JsonConverter newConverter)
+        {
+            for (int i = converters.Count - 1; i >= 0; i--)
+            {
+                if (converters[i].CanConvert(typeof(T)))
+                {
+                    converters.RemoveAt(i);
+                }
+            }
+            converters.Add(newConverter);
+        }
+
+        /// <summary>
+        /// Resolves property name according <see cref="JsonSerializerOptions.PropertyNamingPolicy"/>.
+        /// <para>If <see cref="JsonSerializerOptions.PropertyNamingPolicy"/> is not specified then original <paramref name="propertyName"/> returns.</para>
         /// </summary>
         /// <param name="serializerOptions">The serializer options to use name resolve.</param>
         /// <param name="propertyName">Property name.</param>
@@ -15,12 +109,26 @@ namespace NodaTime.Serialization.SystemText
         internal static string ResolvePropertyName(this JsonSerializerOptions serializerOptions, string propertyName) =>
             (serializerOptions.PropertyNamingPolicy)?.ConvertName(propertyName) ?? propertyName;
 
+        /// <summary>
+        /// Retrieves the <see cref="JsonConverter"/> from <paramref name="serializerOptions"/> and deserializes the object as <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="serializerOptions">The serializer options to use.</param>
+        /// <param name="reader">Json reader.</param>
+        /// <typeparam name="T">The type of object to read.</typeparam>
+        /// <returns>The deserialized object of type <typeparamref name="T"/>.</returns>
         internal static T ReadType<T>(this JsonSerializerOptions serializerOptions, ref Utf8JsonReader reader)
         {
             var converter = (JsonConverter<T>)serializerOptions.GetConverter(typeof(T));
             return converter.Read(ref reader, typeof(T), serializerOptions);
         }
 
+        /// <summary>
+        /// Retrieves the <see cref="JsonConverter"/> from <paramref name="serializerOptions"/> and serializes the object as <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="serializerOptions">The serializer options to use.</param>
+        /// <param name="writer">Json writer.</param>
+        /// <param name="value">The value to serialize</param>
+        /// <typeparam name="T">The type of object to write.</typeparam>
         internal static void WriteType<T>(this JsonSerializerOptions serializerOptions, Utf8JsonWriter writer, T value)
         {
             var converter = (JsonConverter<T>)serializerOptions.GetConverter(typeof(T));

--- a/src/NodaTime.Serialization.SystemText/NodaConverterBase.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaConverterBase.cs
@@ -12,7 +12,7 @@ using NodaTime.Utility;
 namespace NodaTime.Serialization.SystemText
 {
     /// <summary>
-    /// Base class for all the System.Text.NET converters which handle value types (which is most of them).
+    /// Base class for all the System.Text.Json converters which handle value types (which is most of them).
     /// This deals handles all the boilerplate code dealing with nullity.
     /// </summary>
     /// <typeparam name="T">The type to convert to/from JSON.</typeparam>
@@ -32,12 +32,6 @@ namespace NodaTime.Serialization.SystemText
         private static readonly Type NullableT = typeof(T).GetTypeInfo().IsValueType
             ? typeof(Nullable<>).MakeGenericType(typeof(T)) : typeof(T);
 
-        // TODO: It's not clear whether we *should* support inheritance here. The Json.NET docs
-        // aren't clear on when this is used - is it for reading or writing? If it's for both, that's
-        // a problem: our "writer" may be okay for subclasses, but that doesn't mean the "reader" is.
-        // This may well only be an issue for DateTimeZone, as everything else uses a sealed type (e.g. Period)
-        // or a value type.
-
         /// <summary>
         /// Returns whether or not this converter supports the given type.
         /// </summary>
@@ -51,10 +45,9 @@ namespace NodaTime.Serialization.SystemText
         /// <summary>
         /// Converts the JSON stored in a reader into the relevant Noda Time type.
         /// </summary>
-        /// <param name="reader">The Json.NET reader to read data from.</param>
+        /// <param name="reader">The json reader to read data from.</param>
         /// <param name="objectType">The type to convert the JSON to.</param>
-        /// <param name="existingValue">An existing value; ignored by this converter.</param>
-        /// <param name="serializer">A serializer to use for any embedded deserialization.</param>
+        /// <param name="options">A serializer options to use for any embedded deserialization.</param>
         /// <exception cref="InvalidNodaDataException">The JSON was invalid for this converter.</exception>
         /// <returns>The deserialized value.</returns>
         public override T Read(ref Utf8JsonReader reader, Type objectType, JsonSerializerOptions options)
@@ -100,7 +93,7 @@ namespace NodaTime.Serialization.SystemText
         /// a value of type T.
         /// </summary>
         /// <param name="reader">The JSON reader to pull data from</param>
-        /// <param name="serializer">The serializer to use for nested serialization</param>
+        /// <param name="options">The serializer options to use for nested serialization</param>
         /// <returns>The deserialized value of type T.</returns>
         protected abstract T ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options);
 
@@ -109,7 +102,7 @@ namespace NodaTime.Serialization.SystemText
         /// </summary>
         /// <param name="writer">The writer to write the JSON to.</param>
         /// <param name="value">The value to write.</param>
-        /// <param name="serializer">The serializer to use for any embedded serialization.</param>
+        /// <param name="options">The serializer options to use for any embedded serialization.</param>
         public override void Write(Utf8JsonWriter writer,
             T value, JsonSerializerOptions options)
         {
@@ -124,7 +117,7 @@ namespace NodaTime.Serialization.SystemText
         /// </summary>
         /// <param name="writer">The writer to write JSON data to</param>
         /// <param name="value">The value to serializer</param>
-        /// <param name="serializer">The serializer to use for nested serialization</param>
+        /// <param name="options">The serializer options to use for nested serialization</param>
         protected abstract void WriteJsonImpl(Utf8JsonWriter writer,
             T value, JsonSerializerOptions options);
     }

--- a/src/NodaTime.Serialization.SystemText/NodaConverterBase.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaConverterBase.cs
@@ -19,30 +19,6 @@ namespace NodaTime.Serialization.SystemText
     public abstract class NodaConverterBase<T> : JsonConverter<T>
     {
         /// <summary>
-        /// Default constructor.
-        /// </summary>
-        protected NodaConverterBase()
-        {
-        }
-
-        // For value types and sealed classes, we can optimize and not call IsAssignableFrom.
-        private static readonly bool CheckAssignableFrom =
-            !(typeof(T).GetTypeInfo().IsValueType || (typeof(T).GetTypeInfo().IsClass && typeof(T).GetTypeInfo().IsSealed));
-
-        private static readonly Type NullableT = typeof(T).GetTypeInfo().IsValueType
-            ? typeof(Nullable<>).MakeGenericType(typeof(T)) : typeof(T);
-
-        /// <summary>
-        /// Returns whether or not this converter supports the given type.
-        /// </summary>
-        /// <param name="objectType">The type to check for compatibility.</param>
-        /// <returns>True if the given type is supported by this converter (including the nullable form for
-        /// value types); false otherwise.</returns>
-        public override bool CanConvert(Type objectType) =>
-            objectType == typeof(T) || objectType == NullableT ||
-            (CheckAssignableFrom && typeof(T).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()));
-
-        /// <summary>
         /// Converts the JSON stored in a reader into the relevant Noda Time type.
         /// </summary>
         /// <param name="reader">The json reader to read data from.</param>
@@ -52,39 +28,15 @@ namespace NodaTime.Serialization.SystemText
         /// <returns>The deserialized value.</returns>
         public override T Read(ref Utf8JsonReader reader, Type objectType, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonTokenType.Null)
-            {
-                Preconditions.CheckData(objectType == NullableT,
-                    "Cannot convert null value to {0}",
-                    objectType);
-                return default;
-            }
-
-            // Handle empty strings automatically
-            if (reader.TokenType == JsonTokenType.String)
-            {
-                string value = reader.GetString();
-                if (value == "")
-                {
-                    Preconditions.CheckData(objectType == NullableT,
-                        "Cannot convert null value to {0}",
-                        objectType);
-                    return default;
-                }
-            }
-
             try
             {
-                // Delegate to the concrete subclass. At this point we know that we don't want to return null, so we
-                // can ask the subclass to return a T, which we will box. That will be valid even if objectType is
-                // T? because the boxed form of a non-null T? value is just the boxed value itself.
-
+                // Delegate to the concrete subclass.
                 // Note that we don't currently pass existingValue down; we could change this if we ever found a use for it.
                 return ReadJsonImpl(ref reader, options);
             }
             catch (Exception ex)
             {
-                throw new SerializationException($"Cannot convert value to {objectType}", ex);
+                throw new JsonException($"Cannot convert value to {objectType}", ex);
             }
         }
 
@@ -106,8 +58,6 @@ namespace NodaTime.Serialization.SystemText
         public override void Write(Utf8JsonWriter writer,
             T value, JsonSerializerOptions options)
         {
-            // Json.NET should prevent this happening, but let's validate...
-            Preconditions.CheckNotNull(value, nameof(value));
             WriteJsonImpl(writer, value, options);
         }
 

--- a/src/NodaTime.Serialization.SystemText/NodaConverterBase.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaConverterBase.cs
@@ -1,0 +1,131 @@
+// Copyright 2019 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NodaTime.Utility;
+
+namespace NodaTime.Serialization.SystemText
+{
+    /// <summary>
+    /// Base class for all the System.Text.NET converters which handle value types (which is most of them).
+    /// This deals handles all the boilerplate code dealing with nullity.
+    /// </summary>
+    /// <typeparam name="T">The type to convert to/from JSON.</typeparam>
+    public abstract class NodaConverterBase<T> : JsonConverter<T>
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        protected NodaConverterBase()
+        {
+        }
+
+        // For value types and sealed classes, we can optimize and not call IsAssignableFrom.
+        private static readonly bool CheckAssignableFrom =
+            !(typeof(T).GetTypeInfo().IsValueType || (typeof(T).GetTypeInfo().IsClass && typeof(T).GetTypeInfo().IsSealed));
+
+        private static readonly Type NullableT = typeof(T).GetTypeInfo().IsValueType
+            ? typeof(Nullable<>).MakeGenericType(typeof(T)) : typeof(T);
+
+        // TODO: It's not clear whether we *should* support inheritance here. The Json.NET docs
+        // aren't clear on when this is used - is it for reading or writing? If it's for both, that's
+        // a problem: our "writer" may be okay for subclasses, but that doesn't mean the "reader" is.
+        // This may well only be an issue for DateTimeZone, as everything else uses a sealed type (e.g. Period)
+        // or a value type.
+
+        /// <summary>
+        /// Returns whether or not this converter supports the given type.
+        /// </summary>
+        /// <param name="objectType">The type to check for compatibility.</param>
+        /// <returns>True if the given type is supported by this converter (including the nullable form for
+        /// value types); false otherwise.</returns>
+        public override bool CanConvert(Type objectType) =>
+            objectType == typeof(T) || objectType == NullableT ||
+            (CheckAssignableFrom && typeof(T).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()));
+
+        /// <summary>
+        /// Converts the JSON stored in a reader into the relevant Noda Time type.
+        /// </summary>
+        /// <param name="reader">The Json.NET reader to read data from.</param>
+        /// <param name="objectType">The type to convert the JSON to.</param>
+        /// <param name="existingValue">An existing value; ignored by this converter.</param>
+        /// <param name="serializer">A serializer to use for any embedded deserialization.</param>
+        /// <exception cref="InvalidNodaDataException">The JSON was invalid for this converter.</exception>
+        /// <returns>The deserialized value.</returns>
+        public override T Read(ref Utf8JsonReader reader, Type objectType, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                Preconditions.CheckData(objectType == NullableT,
+                    "Cannot convert null value to {0}",
+                    objectType);
+                return default;
+            }
+
+            // Handle empty strings automatically
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                string value = reader.GetString();
+                if (value == "")
+                {
+                    Preconditions.CheckData(objectType == NullableT,
+                        "Cannot convert null value to {0}",
+                        objectType);
+                    return default;
+                }
+            }
+
+            try
+            {
+                // Delegate to the concrete subclass. At this point we know that we don't want to return null, so we
+                // can ask the subclass to return a T, which we will box. That will be valid even if objectType is
+                // T? because the boxed form of a non-null T? value is just the boxed value itself.
+
+                // Note that we don't currently pass existingValue down; we could change this if we ever found a use for it.
+                return ReadJsonImpl(ref reader, options);
+            }
+            catch (Exception ex)
+            {
+                throw new SerializationException($"Cannot convert value to {objectType}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Implemented by concrete subclasses, this performs the final conversion from a non-null JSON value to
+        /// a value of type T.
+        /// </summary>
+        /// <param name="reader">The JSON reader to pull data from</param>
+        /// <param name="serializer">The serializer to use for nested serialization</param>
+        /// <returns>The deserialized value of type T.</returns>
+        protected abstract T ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options);
+
+        /// <summary>
+        /// Writes the given value to a Json.NET writer.
+        /// </summary>
+        /// <param name="writer">The writer to write the JSON to.</param>
+        /// <param name="value">The value to write.</param>
+        /// <param name="serializer">The serializer to use for any embedded serialization.</param>
+        public override void Write(Utf8JsonWriter writer,
+            T value, JsonSerializerOptions options)
+        {
+            // Json.NET should prevent this happening, but let's validate...
+            Preconditions.CheckNotNull(value, nameof(value));
+            WriteJsonImpl(writer, value, options);
+        }
+
+        /// <summary>
+        /// Implemented by concrete subclasses, this performs the final write operation for a non-null value of type T
+        /// to JSON.
+        /// </summary>
+        /// <param name="writer">The writer to write JSON data to</param>
+        /// <param name="value">The value to serializer</param>
+        /// <param name="serializer">The serializer to use for nested serialization</param>
+        protected abstract void WriteJsonImpl(Utf8JsonWriter writer,
+            T value, JsonSerializerOptions options);
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/NodaConverters.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaConverters.cs
@@ -32,62 +32,62 @@ namespace NodaTime.Serialization.SystemText
         /// Converter for local dates and times, using the ISO-8601 date/time pattern, extended as required to accommodate milliseconds and ticks.
         /// No time zone designator is applied.
         /// </summary>
-        public static JsonConverter LocalDateTimeConverter { get; }
+        public static JsonConverter<LocalDateTime> LocalDateTimeConverter { get; }
             = new NodaPatternConverter<LocalDateTime>(
                 LocalDateTimePattern.ExtendedIso, CreateIsoValidator<LocalDateTime>(x => x.Calendar));
 
         /// <summary>
         /// Converter for local times, using the ISO-8601 time pattern, extended as required to accommodate milliseconds and ticks.
         /// </summary>
-        public static JsonConverter LocalTimeConverter { get; }
+        public static JsonConverter<LocalTime> LocalTimeConverter { get; }
             = new NodaPatternConverter<LocalTime>(LocalTimePattern.ExtendedIso);
 
         /// <summary>
         /// Converter for intervals. This must be used in a serializer which also has an instant converter.
         /// </summary>
-        public static JsonConverter IntervalConverter { get; } = new NodaIntervalConverter();
+        public static JsonConverter<Interval> IntervalConverter { get; } = new NodaIntervalConverter();
 
         /// <summary>
         /// Converter for intervals using extended ISO-8601 format, as output by <see cref="Interval.ToString"/>.
         /// </summary>
-        public static JsonConverter IsoIntervalConverter { get; }
+        public static JsonConverter<Interval> IsoIntervalConverter { get; }
             = new NodaIsoIntervalConverter();
 
         /// <summary>
         /// Converter for date intervals. This must be used in a serializer which also has a local date converter.
         /// </summary>
-        public static JsonConverter DateIntervalConverter { get; } = new NodaDateIntervalConverter();
+        public static JsonConverter<DateInterval> DateIntervalConverter { get; } = new NodaDateIntervalConverter();
 
         /// <summary>
         /// Converter for date intervals using ISO-8601 format, as defined by <see cref="LocalDatePattern.Iso"/>.
         /// </summary>
-        public static JsonConverter IsoDateIntervalConverter { get; }
+        public static JsonConverter<DateInterval> IsoDateIntervalConverter { get; }
             = new NodaIsoDateIntervalConverter();
 
         /// <summary>
         /// Converter for offsets.
         /// </summary>
-        public static JsonConverter OffsetConverter { get; }
+        public static JsonConverter<Offset> OffsetConverter { get; }
             = new NodaPatternConverter<Offset>(OffsetPattern.GeneralInvariant);
 
         /// <summary>
         /// Converter for offset date/times.
         /// </summary>
-        public static JsonConverter OffsetDateTimeConverter { get; } =
+        public static JsonConverter<OffsetDateTime> OffsetDateTimeConverter { get; } =
             new NodaPatternConverter<OffsetDateTime>(
                 OffsetDateTimePattern.Rfc3339, CreateIsoValidator<OffsetDateTime>(x => x.Calendar));
 
         /// <summary>
         /// Converter for offset dates.
         /// </summary>
-        public static JsonConverter OffsetDateConverter { get; } =
+        public static JsonConverter<OffsetDate> OffsetDateConverter { get; } =
             new NodaPatternConverter<OffsetDate>(
                 OffsetDatePattern.GeneralIso, CreateIsoValidator<OffsetDate>(x => x.Calendar));
 
         /// <summary>
         /// Converter for offset times.
         /// </summary>
-        public static JsonConverter OffsetTimeConverter { get; } =
+        public static JsonConverter<OffsetTime> OffsetTimeConverter { get; } =
             new NodaPatternConverter<OffsetTime>(OffsetTimePattern.ExtendedIso);
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace NodaTime.Serialization.SystemText
         /// </summary>
         /// <param name="provider">The time zone provider to use when parsing.</param>
         /// <returns>A converter to handle <see cref="ZonedDateTime"/>.</returns>
-        public static JsonConverter CreateZonedDateTimeConverter(IDateTimeZoneProvider provider) =>
+        public static JsonConverter<ZonedDateTime> CreateZonedDateTimeConverter(IDateTimeZoneProvider provider) =>
             new NodaPatternConverter<ZonedDateTime>(
                 ZonedDateTimePattern.CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFFFo<G> z", provider),
                 CreateIsoValidator<ZonedDateTime>(x => x.Calendar));
@@ -111,14 +111,14 @@ namespace NodaTime.Serialization.SystemText
         /// <summary>
         /// Converter for durations.
         /// </summary>
-        public static JsonConverter DurationConverter { get; }
+        public static JsonConverter<Duration> DurationConverter { get; }
             = new NodaPatternConverter<Duration>(DurationPattern.CreateWithInvariantCulture("-H:mm:ss.FFFFFFFFF"));
 
         /// <summary>
         /// Round-tripping converter for periods. Use this when you really want to preserve information,
         /// and don't need interoperability with systems expecting ISO.
         /// </summary>
-        public static JsonConverter RoundtripPeriodConverter { get; }
+        public static JsonConverter<Period> RoundtripPeriodConverter { get; }
             = new NodaPatternConverter<Period>(PeriodPattern.Roundtrip);
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace NodaTime.Serialization.SystemText
         /// ISO durations (~= Noda Time periods). However, note that Noda Time can have negative periods. Note that
         /// this converter losees information - after serialization and deserialization, "90 minutes" will become "an hour and 30 minutes".
         /// </summary>
-        public static JsonConverter NormalizingIsoPeriodConverter { get; }
+        public static JsonConverter<Period> NormalizingIsoPeriodConverter { get; }
             = new NodaPatternConverter<Period>(PeriodPattern.NormalizingIso);
 
         private static Action<T> CreateIsoValidator<T>(Func<T, CalendarSystem> calendarProjection) => value =>

--- a/src/NodaTime.Serialization.SystemText/NodaConverters.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaConverters.cs
@@ -105,7 +105,7 @@ namespace NodaTime.Serialization.SystemText
         /// </summary>
         /// <param name="provider">The time zone provider to use when parsing.</param>
         /// <returns>A converter to handle <see cref="DateTimeZone"/>.</returns>
-        public static JsonConverter CreateDateTimeZoneConverter(IDateTimeZoneProvider provider) =>
+        public static JsonConverter<DateTimeZone> CreateDateTimeZoneConverter(IDateTimeZoneProvider provider) =>
             new NodaDateTimeZoneConverter(provider);
 
         /// <summary>

--- a/src/NodaTime.Serialization.SystemText/NodaConverters.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaConverters.cs
@@ -1,0 +1,141 @@
+// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using System.Text.Json.Serialization;
+using NodaTime.Text;
+
+namespace NodaTime.Serialization.SystemText
+{
+    /// <summary>
+    /// Convenience class to expose preconfigured converters for Noda Time types, and factory methods
+    /// for creating those which require parameters.
+    /// </summary>
+    public static class NodaConverters
+    {
+        /// <summary>
+        /// Converter for instants, using the ISO-8601 date/time pattern, extended as required to accommodate milliseconds and ticks, and
+        /// specifying 'Z' at the end to show it's effectively in UTC.
+        /// </summary>
+        public static JsonConverter<Instant> InstantConverter { get; }
+            = new NodaPatternConverter<Instant>(InstantPattern.ExtendedIso);
+
+        /// <summary>
+        /// Converter for local dates, using the ISO-8601 date pattern.
+        /// </summary>
+        public static JsonConverter LocalDateConverter { get; }
+            = new NodaPatternConverter<LocalDate>(
+                LocalDatePattern.Iso, CreateIsoValidator<LocalDate>(x => x.Calendar));
+
+        /// <summary>
+        /// Converter for local dates and times, using the ISO-8601 date/time pattern, extended as required to accommodate milliseconds and ticks.
+        /// No time zone designator is applied.
+        /// </summary>
+        public static JsonConverter LocalDateTimeConverter { get; }
+            = new NodaPatternConverter<LocalDateTime>(
+                LocalDateTimePattern.ExtendedIso, CreateIsoValidator<LocalDateTime>(x => x.Calendar));
+
+        /// <summary>
+        /// Converter for local times, using the ISO-8601 time pattern, extended as required to accommodate milliseconds and ticks.
+        /// </summary>
+        public static JsonConverter LocalTimeConverter { get; }
+            = new NodaPatternConverter<LocalTime>(LocalTimePattern.ExtendedIso);
+
+        /// <summary>
+        /// Converter for intervals. This must be used in a serializer which also has an instant converter.
+        /// </summary>
+        public static JsonConverter IntervalConverter { get; } = new NodaIntervalConverter();
+
+        /// <summary>
+        /// Converter for intervals using extended ISO-8601 format, as output by <see cref="Interval.ToString"/>.
+        /// </summary>
+        public static JsonConverter IsoIntervalConverter { get; }
+            = new NodaIsoIntervalConverter();
+
+        /// <summary>
+        /// Converter for date intervals. This must be used in a serializer which also has a local date converter.
+        /// </summary>
+        public static JsonConverter DateIntervalConverter { get; } = new NodaDateIntervalConverter();
+
+        /// <summary>
+        /// Converter for date intervals using ISO-8601 format, as defined by <see cref="LocalDatePattern.Iso"/>.
+        /// </summary>
+        public static JsonConverter IsoDateIntervalConverter { get; }
+            = new NodaIsoDateIntervalConverter();
+
+        /// <summary>
+        /// Converter for offsets.
+        /// </summary>
+        public static JsonConverter OffsetConverter { get; }
+            = new NodaPatternConverter<Offset>(OffsetPattern.GeneralInvariant);
+
+        /// <summary>
+        /// Converter for offset date/times.
+        /// </summary>
+        public static JsonConverter OffsetDateTimeConverter { get; } =
+            new NodaPatternConverter<OffsetDateTime>(
+                OffsetDateTimePattern.Rfc3339, CreateIsoValidator<OffsetDateTime>(x => x.Calendar));
+
+        /// <summary>
+        /// Converter for offset dates.
+        /// </summary>
+        public static JsonConverter OffsetDateConverter { get; } =
+            new NodaPatternConverter<OffsetDate>(
+                OffsetDatePattern.GeneralIso, CreateIsoValidator<OffsetDate>(x => x.Calendar));
+
+        /// <summary>
+        /// Converter for offset times.
+        /// </summary>
+        public static JsonConverter OffsetTimeConverter { get; } =
+            new NodaPatternConverter<OffsetTime>(OffsetTimePattern.ExtendedIso);
+
+        /// <summary>
+        /// Creates a converter for zoned date/times, using the given time zone provider.
+        /// </summary>
+        /// <param name="provider">The time zone provider to use when parsing.</param>
+        /// <returns>A converter to handle <see cref="ZonedDateTime"/>.</returns>
+        public static JsonConverter CreateZonedDateTimeConverter(IDateTimeZoneProvider provider) =>
+            new NodaPatternConverter<ZonedDateTime>(
+                ZonedDateTimePattern.CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFFFo<G> z", provider),
+                CreateIsoValidator<ZonedDateTime>(x => x.Calendar));
+
+        /// <summary>
+        /// Creates a converter for time zones, using the given provider.
+        /// </summary>
+        /// <param name="provider">The time zone provider to use when parsing.</param>
+        /// <returns>A converter to handle <see cref="DateTimeZone"/>.</returns>
+        public static JsonConverter CreateDateTimeZoneConverter(IDateTimeZoneProvider provider) =>
+            new NodaDateTimeZoneConverter(provider);
+
+        /// <summary>
+        /// Converter for durations.
+        /// </summary>
+        public static JsonConverter DurationConverter { get; }
+            = new NodaPatternConverter<Duration>(DurationPattern.CreateWithInvariantCulture("-H:mm:ss.FFFFFFFFF"));
+
+        /// <summary>
+        /// Round-tripping converter for periods. Use this when you really want to preserve information,
+        /// and don't need interoperability with systems expecting ISO.
+        /// </summary>
+        public static JsonConverter RoundtripPeriodConverter { get; }
+            = new NodaPatternConverter<Period>(PeriodPattern.Roundtrip);
+
+        /// <summary>
+        /// Normalizing ISO converter for periods. Use this when you want compatibility with systems expecting
+        /// ISO durations (~= Noda Time periods). However, note that Noda Time can have negative periods. Note that
+        /// this converter losees information - after serialization and deserialization, "90 minutes" will become "an hour and 30 minutes".
+        /// </summary>
+        public static JsonConverter NormalizingIsoPeriodConverter { get; }
+            = new NodaPatternConverter<Period>(PeriodPattern.NormalizingIso);
+
+        private static Action<T> CreateIsoValidator<T>(Func<T, CalendarSystem> calendarProjection) => value =>
+        {
+            var calendar = calendarProjection(value);
+            // We rely on CalendarSystem.Iso being a singleton here.
+            Preconditions.CheckArgument(calendar == CalendarSystem.Iso,
+                "Values of type {0} must (currently) use the ISO calendar in order to be serialized.",
+                typeof(T).Name);
+        };
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/NodaConverters.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaConverters.cs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
@@ -24,7 +24,7 @@ namespace NodaTime.Serialization.SystemText
         /// <summary>
         /// Converter for local dates, using the ISO-8601 date pattern.
         /// </summary>
-        public static JsonConverter LocalDateConverter { get; }
+        public static JsonConverter<LocalDate> LocalDateConverter { get; }
             = new NodaPatternConverter<LocalDate>(
                 LocalDatePattern.Iso, CreateIsoValidator<LocalDate>(x => x.Calendar));
 

--- a/src/NodaTime.Serialization.SystemText/NodaDateIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaDateIntervalConverter.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
@@ -8,7 +8,7 @@ using NodaTime.Utility;
 namespace NodaTime.Serialization.SystemText
 {
     /// <summary>
-    /// Json.NET converter for <see cref="DateInterval"/> using a compound representation. The start and
+    /// System.Text.Json converter for <see cref="DateInterval"/> using a compound representation. The start and
     /// end aspects of the date interval are represented with separate properties, each parsed and formatted
     /// by the <see cref="LocalDate"/> converter for the serializer provided.
     /// </summary>
@@ -19,7 +19,7 @@ namespace NodaTime.Serialization.SystemText
         /// using the given serializer.
         /// </summary>
         /// <param name="reader">The JSON reader to fetch data from.</param>
-        /// <param name="serializer">The serializer for embedded serialization.</param>
+        /// <param name="options">The serializer options for embedded serialization.</param>
         /// <returns>The <see cref="DateInterval"/> identified in the JSON.</returns>
         protected override DateInterval ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
@@ -69,7 +69,7 @@ namespace NodaTime.Serialization.SystemText
         /// </summary>
         /// <param name="writer">The writer to write JSON to</param>
         /// <param name="value">The date interval to serialize</param>
-        /// <param name="serializer">The serializer for embedded serialization.</param>
+        /// <param name="options">The serializer options for embedded serialization.</param>
         protected override void WriteJsonImpl(Utf8JsonWriter writer, DateInterval value, JsonSerializerOptions options)
         {
             writer.WriteStartObject();

--- a/src/NodaTime.Serialization.SystemText/NodaDateIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaDateIntervalConverter.cs
@@ -1,0 +1,88 @@
+// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System.Text.Json;
+using NodaTime.Utility;
+
+namespace NodaTime.Serialization.SystemText
+{
+    /// <summary>
+    /// Json.NET converter for <see cref="DateInterval"/> using a compound representation. The start and
+    /// end aspects of the date interval are represented with separate properties, each parsed and formatted
+    /// by the <see cref="LocalDate"/> converter for the serializer provided.
+    /// </summary>
+    internal sealed class NodaDateIntervalConverter : NodaConverterBase<DateInterval>
+    {
+        /// <summary>
+        /// Reads Start and End properties for the start and end of a date interval, converting them to local dates
+        /// using the given serializer.
+        /// </summary>
+        /// <param name="reader">The JSON reader to fetch data from.</param>
+        /// <param name="serializer">The serializer for embedded serialization.</param>
+        /// <returns>The <see cref="DateInterval"/> identified in the JSON.</returns>
+        protected override DateInterval ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            LocalDate? startLocalDate = null;
+            LocalDate? endLocalDate = null;
+            while (reader.Read())
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    break;
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    break;
+                }
+
+                var startPropertyName = options.ResolvePropertyName(nameof(Interval.Start));
+                if (propertyName == startPropertyName)
+                {
+                    startLocalDate = options.ReadType<LocalDate>(ref reader);
+                }
+
+                var endPropertyName = options.ResolvePropertyName(nameof(Interval.End));
+                if (propertyName == endPropertyName)
+                {
+                    endLocalDate = options.ReadType<LocalDate>(ref reader);
+                }
+            }
+
+            if (!startLocalDate.HasValue)
+            {
+                throw new InvalidNodaDataException("Expected date interval; start date was missing.");
+            }
+
+            if (!endLocalDate.HasValue)
+            {
+                throw new InvalidNodaDataException("Expected date interval; end date was missing.");
+            }
+
+            return new DateInterval(startLocalDate.Value, endLocalDate.Value);
+        }
+
+        /// <summary>
+        /// Serializes the date interval as start/end local dates.
+        /// </summary>
+        /// <param name="writer">The writer to write JSON to</param>
+        /// <param name="value">The date interval to serialize</param>
+        /// <param name="serializer">The serializer for embedded serialization.</param>
+        protected override void WriteJsonImpl(Utf8JsonWriter writer, DateInterval value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+
+            var startPropertyName = options.ResolvePropertyName(nameof(Interval.Start));
+            writer.WritePropertyName(startPropertyName);
+            options.WriteType(writer, value.Start);
+
+            var endPropertyName = options.ResolvePropertyName(nameof(Interval.End));
+            writer.WritePropertyName(endPropertyName);
+            options.WriteType(writer, value.End);
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/NodaDateTimeZoneConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaDateTimeZoneConverter.cs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
@@ -8,7 +8,7 @@ using NodaTime.TimeZones;
 namespace NodaTime.Serialization.SystemText
 {
     /// <summary>
-    /// Json.NET converter for <see cref="DateTimeZone"/>.
+    /// System.Text.Json converter for <see cref="DateTimeZone"/>.
     /// </summary>
     internal sealed class NodaDateTimeZoneConverter : NodaConverterBase<DateTimeZone>
     {
@@ -24,7 +24,7 @@ namespace NodaTime.Serialization.SystemText
         /// Reads the time zone ID (which must be a string) from the reader, and converts it to a time zone.
         /// </summary>
         /// <param name="reader">The JSON reader to fetch data from.</param>
-        /// <param name="options">The serialization options to use.</param>
+        /// <param name="options">The serialization options to use for nested serialization.</param>
         /// <exception cref="DateTimeZoneNotFoundException">The provider does not support a time zone with the given ID.</exception>
         /// <returns>The <see cref="DateTimeZone"/> identified in the JSON, or null.</returns>
         protected override DateTimeZone ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
@@ -40,9 +40,9 @@ namespace NodaTime.Serialization.SystemText
         /// <summary>
         /// Writes the time zone ID to the writer.
         /// </summary>
-        /// <param name="writer">The writer to write JSON data to</param>
-        /// <param name="value">The value to serializer</param>
-        /// <param name="options">The serialization options to use</param>
+        /// <param name="writer">The writer to write JSON data to.</param>
+        /// <param name="value">The value to serializer.</param>
+        /// <param name="options">The serialization options to use for nested serialization.</param>
         protected override void WriteJsonImpl(Utf8JsonWriter writer, DateTimeZone value, JsonSerializerOptions options)
         {
             writer.WriteStringValue(value.Id);

--- a/src/NodaTime.Serialization.SystemText/NodaDateTimeZoneConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaDateTimeZoneConverter.cs
@@ -1,0 +1,51 @@
+// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System.Text.Json;
+using NodaTime.TimeZones;
+
+namespace NodaTime.Serialization.SystemText
+{
+    /// <summary>
+    /// Json.NET converter for <see cref="DateTimeZone"/>.
+    /// </summary>
+    internal sealed class NodaDateTimeZoneConverter : NodaConverterBase<DateTimeZone>
+    {
+        private readonly IDateTimeZoneProvider provider;
+
+        /// <param name="provider">Provides the <see cref="DateTimeZone"/> that corresponds to each time zone ID in the JSON string.</param>
+        public NodaDateTimeZoneConverter(IDateTimeZoneProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        /// <summary>
+        /// Reads the time zone ID (which must be a string) from the reader, and converts it to a time zone.
+        /// </summary>
+        /// <param name="reader">The JSON reader to fetch data from.</param>
+        /// <param name="options">The serialization options to use.</param>
+        /// <exception cref="DateTimeZoneNotFoundException">The provider does not support a time zone with the given ID.</exception>
+        /// <returns>The <see cref="DateTimeZone"/> identified in the JSON, or null.</returns>
+        protected override DateTimeZone ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            Preconditions.CheckData(reader.TokenType == JsonTokenType.String,
+                "Unexpected token parsing instant. Expected String, got {0}.",
+                reader.TokenType);
+
+            var timeZoneId = reader.GetString();
+            return provider[timeZoneId];
+        }
+
+        /// <summary>
+        /// Writes the time zone ID to the writer.
+        /// </summary>
+        /// <param name="writer">The writer to write JSON data to</param>
+        /// <param name="value">The value to serializer</param>
+        /// <param name="options">The serialization options to use</param>
+        protected override void WriteJsonImpl(Utf8JsonWriter writer, DateTimeZone value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.Id);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/NodaIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaIntervalConverter.cs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
@@ -7,7 +7,7 @@ using System.Text.Json;
 namespace NodaTime.Serialization.SystemText
 {
     /// <summary>
-    /// Json.NET converter for <see cref="Interval"/> using a compound representation. The start and
+    /// System.Text.Json converter for <see cref="Interval"/> using a compound representation. The start and
     /// end aspects of the interval are represented with separate properties, each parsed and formatted
     /// by the <see cref="Instant"/> converter for the serializer provided.
     /// </summary>
@@ -18,7 +18,7 @@ namespace NodaTime.Serialization.SystemText
         /// using the given serializer.
         /// </summary>
         /// <param name="reader">The JSON reader to fetch data from.</param>
-        /// <param name="serializer">The serializer for embedded serialization.</param>
+        /// <param name="options">The serializer options for embedded serialization.</param>
         /// <returns>The <see cref="Interval"/> identified in the JSON.</returns>
         protected override Interval ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
@@ -60,7 +60,7 @@ namespace NodaTime.Serialization.SystemText
         /// </summary>
         /// <param name="writer">The writer to write JSON to</param>
         /// <param name="value">The interval to serialize</param>
-        /// <param name="options">The serializer for embedded serialization.</param>
+        /// <param name="options">The serializer options for embedded serialization.</param>
         protected override void WriteJsonImpl(Utf8JsonWriter writer, Interval value, JsonSerializerOptions options)
         {
             writer.WriteStartObject();

--- a/src/NodaTime.Serialization.SystemText/NodaIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaIntervalConverter.cs
@@ -1,0 +1,83 @@
+// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System.Text.Json;
+
+namespace NodaTime.Serialization.SystemText
+{
+    /// <summary>
+    /// Json.NET converter for <see cref="Interval"/> using a compound representation. The start and
+    /// end aspects of the interval are represented with separate properties, each parsed and formatted
+    /// by the <see cref="Instant"/> converter for the serializer provided.
+    /// </summary>
+    internal sealed class NodaIntervalConverter : NodaConverterBase<Interval>
+    {
+        /// <summary>
+        /// Reads Start and End properties for the start and end of an interval, converting them to instants
+        /// using the given serializer.
+        /// </summary>
+        /// <param name="reader">The JSON reader to fetch data from.</param>
+        /// <param name="serializer">The serializer for embedded serialization.</param>
+        /// <returns>The <see cref="Interval"/> identified in the JSON.</returns>
+        protected override Interval ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            Instant? startInstant = null;
+            Instant? endInstant = null;
+            while (reader.Read())
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    break;
+                }
+
+                var propertyName = reader.GetString();
+                // If we haven't got a property value, that's pretty weird. Break out of the loop,
+                // and let JSON.NET fail appropriately...
+                if (!reader.Read())
+                {
+                    break;
+                }
+
+                var startPropertyName = options.ResolvePropertyName(nameof(Interval.Start));
+                if (propertyName == startPropertyName)
+                {
+                    startInstant = options.ReadType<Instant>(ref reader);
+                }
+
+                var endPropertyName = options.ResolvePropertyName(nameof(Interval.End));
+                if (propertyName == endPropertyName)
+                {
+                    endInstant = options.ReadType<Instant>(ref reader);
+                }
+            }
+
+            return new Interval(startInstant, endInstant);
+        }
+
+        /// <summary>
+        /// Serializes the interval as start/end instants.
+        /// </summary>
+        /// <param name="writer">The writer to write JSON to</param>
+        /// <param name="value">The interval to serialize</param>
+        /// <param name="options">The serializer for embedded serialization.</param>
+        protected override void WriteJsonImpl(Utf8JsonWriter writer, Interval value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+
+            if (value.HasStart)
+            {
+                var startPropertyName = options.ResolvePropertyName(nameof(Interval.Start));
+                writer.WritePropertyName(startPropertyName);
+                options.WriteType(writer, value.Start);
+            }
+            if (value.HasEnd)
+            {
+                var endPropertyName = options.ResolvePropertyName(nameof(Interval.End));
+                writer.WritePropertyName(endPropertyName);
+                options.WriteType(writer, value.End);
+            }
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/NodaIsoDateIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaIsoDateIntervalConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+﻿// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
@@ -9,10 +9,17 @@ using NodaTime.Utility;
 namespace NodaTime.Serialization.SystemText
 {
     /// <summary>
-    /// Json.NET converter for <see cref="DateInterval"/>.
+    /// System.Text.Json converter for <see cref="DateInterval"/>.
     /// </summary>
     internal sealed class NodaIsoDateIntervalConverter : NodaConverterBase<DateInterval>
     {
+        /// <summary>
+        /// Reads Start and End properties for the start and end of an interval, converting them to instants
+        /// using the given serializer.
+        /// </summary>
+        /// <param name="reader">The JSON reader to fetch data from.</param>
+        /// <param name="options">The serializer options for embedded serialization.</param>
+        /// <returns>The <see cref="Interval"/> identified in the JSON.</returns>
         protected override DateInterval ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             if (reader.TokenType != JsonTokenType.String)
@@ -51,7 +58,7 @@ namespace NodaTime.Serialization.SystemText
         /// </summary>
         /// <param name="writer">The writer to write JSON to</param>
         /// <param name="value">The date interval to serialize</param>
-        /// <param name="serializer">The serializer for embedded serialization.</param>
+        /// <param name="options">The serializer options for embedded serialization.</param>
         protected override void WriteJsonImpl(Utf8JsonWriter writer, DateInterval value, JsonSerializerOptions options)
         {
             var pattern = LocalDatePattern.Iso;

--- a/src/NodaTime.Serialization.SystemText/NodaIsoDateIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaIsoDateIntervalConverter.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System.Text.Json;
+using NodaTime.Text;
+using NodaTime.Utility;
+
+namespace NodaTime.Serialization.SystemText
+{
+    /// <summary>
+    /// Json.NET converter for <see cref="DateInterval"/>.
+    /// </summary>
+    internal sealed class NodaIsoDateIntervalConverter : NodaConverterBase<DateInterval>
+    {
+        protected override DateInterval ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new InvalidNodaDataException(
+                    $"Unexpected token parsing DateInterval. Expected String, got {reader.TokenType}.");
+            }
+            string text = reader.GetString();
+            int slash = text.IndexOf('/');
+            if (slash == -1)
+            {
+                throw new InvalidNodaDataException("Expected ISO-8601-formatted date interval; slash was missing.");
+            }
+
+            string startText = text.Substring(0, slash);
+            if (startText == "")
+            {
+                throw new InvalidNodaDataException("Expected ISO-8601-formatted date interval; start date was missing.");
+            }
+
+            string endText = text.Substring(slash + 1);
+            if (endText == "")
+            {
+                throw new InvalidNodaDataException("Expected ISO-8601-formatted date interval; end date was missing.");
+            }
+
+            var pattern = LocalDatePattern.Iso;
+            var start = pattern.Parse(startText).Value;
+            var end = pattern.Parse(endText).Value;
+
+            return new DateInterval(start, end);
+        }
+
+        /// <summary>
+        /// Serializes the date interval as start/end dates.
+        /// </summary>
+        /// <param name="writer">The writer to write JSON to</param>
+        /// <param name="value">The date interval to serialize</param>
+        /// <param name="serializer">The serializer for embedded serialization.</param>
+        protected override void WriteJsonImpl(Utf8JsonWriter writer, DateInterval value, JsonSerializerOptions options)
+        {
+            var pattern = LocalDatePattern.Iso;
+            string text = pattern.Format(value.Start) + "/" + pattern.Format(value.End);
+            writer.WriteStringValue(text);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/NodaIsoIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaIsoIntervalConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 The Noda Time Authors. All rights reserved.
+﻿// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
@@ -13,6 +13,13 @@ namespace NodaTime.Serialization.SystemText
     /// </summary>
     internal sealed class NodaIsoIntervalConverter : NodaConverterBase<Interval>
     {
+        /// <summary>
+        /// Reads Start and End properties for the start and end of an interval, converting them to instants
+        /// using the given serializer.
+        /// </summary>
+        /// <param name="reader">The JSON reader to fetch data from.</param>
+        /// <param name="options">The serializer options for embedded serialization.</param>
+        /// <returns>The <see cref="Interval"/> identified in the JSON.</returns>
         protected override Interval ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             if (reader.TokenType != JsonTokenType.String)
@@ -41,7 +48,7 @@ namespace NodaTime.Serialization.SystemText
         /// </summary>
         /// <param name="writer">The writer to write JSON to</param>
         /// <param name="value">The interval to serialize</param>
-        /// <param name="serializer">The serializer for embedded serialization.</param>
+        /// <param name="options">The serializer options for embedded serialization.</param>
         protected override void WriteJsonImpl(Utf8JsonWriter writer, Interval value, JsonSerializerOptions options)
         {
             var pattern = InstantPattern.ExtendedIso;

--- a/src/NodaTime.Serialization.SystemText/NodaIsoIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaIsoIntervalConverter.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2014 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System.Text.Json;
+using NodaTime.Text;
+using NodaTime.Utility;
+
+namespace NodaTime.Serialization.SystemText
+{
+    /// <summary>
+    /// Json.NET converter for <see cref="Interval"/>.
+    /// </summary>
+    internal sealed class NodaIsoIntervalConverter : NodaConverterBase<Interval>
+    {
+        protected override Interval ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new InvalidNodaDataException(
+                    $"Unexpected token parsing Interval. Expected String, got {reader.TokenType}.");
+            }
+            string text = reader.GetString();
+            int slash = text.IndexOf('/');
+            if (slash == -1)
+            {
+                throw new InvalidNodaDataException("Expected ISO-8601-formatted interval; slash was missing.");
+            }
+
+            string startText = text.Substring(0, slash);
+            string endText = text.Substring(slash + 1);
+            var pattern = InstantPattern.ExtendedIso;
+            var start = startText == "" ? (Instant?) null : pattern.Parse(startText).Value;
+            var end = endText == "" ? (Instant?) null : pattern.Parse(endText).Value;
+
+            return new Interval(start, end);
+        }
+
+        /// <summary>
+        /// Serializes the interval as start/end instants.
+        /// </summary>
+        /// <param name="writer">The writer to write JSON to</param>
+        /// <param name="value">The interval to serialize</param>
+        /// <param name="serializer">The serializer for embedded serialization.</param>
+        protected override void WriteJsonImpl(Utf8JsonWriter writer, Interval value, JsonSerializerOptions options)
+        {
+            var pattern = InstantPattern.ExtendedIso;
+            string text = (value.HasStart ? pattern.Format(value.Start) : "") + "/" + (value.HasEnd ? pattern.Format(value.End) : "");
+            writer.WriteStringValue(text);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/NodaPatternConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaPatternConverter.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NodaTime.Text;
+
+namespace NodaTime.Serialization.SystemText
+{
+    public sealed class NodaPatternConverter<T> : JsonConverter<T>
+    {
+        private readonly IPattern<T> pattern;
+        private readonly Action<T> validator;
+
+        public NodaPatternConverter(IPattern<T> pattern, Action<T> validator = null)
+        {
+            this.pattern = pattern;
+            this.validator = validator;
+        }
+
+        public void Read(ref Utf8JsonReader reader,
+            Type type, JsonSerializerOptions options,
+            out T value)
+        {
+            string text = reader.GetString();
+            value = pattern.Parse(text).Value;
+        }
+
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string text = reader.GetString();
+            return pattern.Parse(text).Value;
+        }
+
+        public override void Write(Utf8JsonWriter writer,
+            T value, JsonSerializerOptions options)
+        {
+            validator?.Invoke(value);
+            writer.WriteStringValue(pattern.Format(value));
+        }
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/NodaPatternConverter.cs
+++ b/src/NodaTime.Serialization.SystemText/NodaPatternConverter.cs
@@ -4,11 +4,15 @@
 
 using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using NodaTime.Text;
 
 namespace NodaTime.Serialization.SystemText
 {
+    /// <summary>
+    /// A JSON converter for types which can be represented by a single string value, parsed or formatted
+    /// from an <see cref="IPattern{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type to convert to/from JSON.</typeparam>
     public sealed class NodaPatternConverter<T> : NodaConverterBase<T>
     {
         private readonly IPattern<T> pattern;

--- a/src/NodaTime.Serialization.SystemText/NodaTime.Serialization.SystemText.csproj
+++ b/src/NodaTime.Serialization.SystemText/NodaTime.Serialization.SystemText.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Provides serialization support between Noda Time and System.Text.Json</Description>
+        <AssemblyTitle>Noda Time</AssemblyTitle>
+        <Version>2.2.0</Version>
+        <Authors>Jon Skeet</Authors>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <AssemblyName>NodaTime.Serialization.SystemText</AssemblyName>
+        <AssemblyOriginatorKeyFile>../../NodaTime Release.snk</AssemblyOriginatorKeyFile>
+        <SignAssembly>true</SignAssembly>
+        <PackageTags>nodatime;json</PackageTags>
+        <PackageProjectUrl>http://nodatime.org/</PackageProjectUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/nodatime/nodatime.serialization</RepositoryUrl>
+        <Deterministic>True</Deterministic>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="NodaTime" Version="2.4.5" />
+      <PackageReference Include="System.Text.Json" Version="4.6.0-preview7.19362.9" />
+      <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
+    </ItemGroup>
+
+</Project>

--- a/src/NodaTime.Serialization.SystemText/Preconditions.cs
+++ b/src/NodaTime.Serialization.SystemText/Preconditions.cs
@@ -1,0 +1,35 @@
+// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using NodaTime.Utility;
+
+namespace NodaTime.Serialization.SystemText
+{
+    /// <summary>
+    /// Helper static methods for argument/state validation. (Just the subset used within this library.)
+    /// </summary>
+    internal static class Preconditions
+    {
+        internal static T CheckNotNull<T>(T argument, string paramName)
+            => argument == null ? throw new ArgumentNullException(paramName) : argument;
+
+        internal static void CheckArgument(bool expression, string parameter, string message)
+        {
+            if (!expression)
+            {
+                throw new ArgumentException(message, parameter);
+            }
+        }
+
+        internal static void CheckData<T>(bool expression, string messageFormat, T messageArg)
+        {
+            if (!expression)
+            {
+                string message = string.Format(messageFormat, messageArg);
+                throw new InvalidNodaDataException(message);
+            }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.SystemText/Preconditions.cs
+++ b/src/NodaTime.Serialization.SystemText/Preconditions.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaConverterBaseTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaConverterBaseTest.cs
@@ -35,7 +35,6 @@ namespace NodaTime.Serialization.Test.JsonNet
             var converter = new TestConverter();
 
             Assert.IsNull(JsonConvert.DeserializeObject<int?>("null", converter));
-            Assert.IsNull(JsonConvert.DeserializeObject<int?>("\"\"", converter));
         }
 
         [Test]
@@ -44,7 +43,6 @@ namespace NodaTime.Serialization.Test.JsonNet
             var converter = new TestStringConverter();
 
             Assert.IsNull(JsonConvert.DeserializeObject<string>("null", converter));
-            Assert.IsNull(JsonConvert.DeserializeObject<string>("\"\"", converter));
         }
 
         [Test]
@@ -61,7 +59,6 @@ namespace NodaTime.Serialization.Test.JsonNet
             var converter = new TestConverter();
 
             Assert.Throws<InvalidNodaDataException>(() => JsonConvert.DeserializeObject<int>("null", converter));
-            Assert.Throws<InvalidNodaDataException>(() => JsonConvert.DeserializeObject<int>("\"\"", converter));
         }
 
         [Test]

--- a/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
+++ b/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\NodaTime.Serialization.JsonNet\NodaTime.Serialization.JsonNet.csproj" />
     <ProjectReference Include="..\NodaTime.Serialization.Protobuf\NodaTime.Serialization.Protobuf.csproj" />
+    <ProjectReference Include="..\NodaTime.Serialization.SystemText\NodaTime.Serialization.SystemText.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Serialization.Test/SystemText/DelegatingConverterBaseTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/DelegatingConverterBaseTest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2019 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NodaTime.Serialization.SystemText;
+using NodaTime.Text;
+using NUnit.Framework;
+using NodaConverters = NodaTime.Serialization.SystemText.NodaConverters;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    public class DelegatingConverterBaseTest
+    {
+        [Test]
+        public void Serialize()
+        {
+            string expected = "{'ShortDate':'2017-02-20','LongDate':'20 February 2017'}"
+                .Replace("'", "\"");
+            var date = new LocalDate(2017, 2, 20);
+            var entity = new Entity { ShortDate = date, LongDate = date };
+            var actual = JsonSerializer.Serialize(entity, new JsonSerializerOptions
+            {
+                WriteIndented = false
+            });
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Deserialize()
+        {
+            string json = "{'ShortDate':'2017-02-20','LongDate':'20 February 2017'}"
+                .Replace("'", "\"");
+            var expectedDate = new LocalDate(2017, 2, 20);
+            var entity = JsonSerializer.Deserialize<Entity>(json);
+            Assert.AreEqual(expectedDate, entity.ShortDate);
+            Assert.AreEqual(expectedDate, entity.LongDate);
+        }
+
+        public class Entity
+        {
+            [JsonConverter(typeof(ShortDateConverter))]
+            public LocalDate ShortDate { get; set; }
+
+            [JsonConverter(typeof(LongDateConverter))]
+            public LocalDate LongDate { get; set; }
+        }
+
+        public class ShortDateConverter : DelegatingConverterBase<LocalDate>
+        {
+            public ShortDateConverter() : base(NodaConverters.LocalDateConverter) { }
+        }
+
+        public class LongDateConverter : DelegatingConverterBase<LocalDate>
+        {
+            // No need to create a new one of these each time...
+            private static readonly JsonConverter<LocalDate> converter =
+                new Serialization.SystemText.NodaPatternConverter<LocalDate>(LocalDatePattern.CreateWithInvariantCulture("d MMMM yyyy"));
+
+            public LongDateConverter() : base(converter)
+            {
+            }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/ExtensionsTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/ExtensionsTest.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2019 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System.IO;
+using System.Text.Json;
+using NodaTime.Serialization.SystemText;
+using NUnit.Framework;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    public class ExtensionsTest
+    {
+        [Test]
+        public void Options_ConfigureForNodaTime_DefaultInterval()
+        {
+            var configuredOptions = new JsonSerializerOptions().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+            var explicitOptions = new JsonSerializerOptions
+            {
+                Converters = { NodaConverters.IntervalConverter, NodaConverters.InstantConverter }
+            };
+            var interval = new Interval(Instant.FromUnixTimeTicks(1000L), Instant.FromUnixTimeTicks(20000L));
+            Assert.AreEqual(JsonSerializer.Serialize(interval, explicitOptions),
+                JsonSerializer.Serialize(interval, configuredOptions));
+        }
+
+        [Test]
+        public void Options_ConfigureForNodaTime_WithIsoIntervalConverter()
+        {
+            var configuredOptions = new JsonSerializerOptions().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb).WithIsoIntervalConverter();
+            var explicitOptions = new JsonSerializerOptions { Converters = { NodaConverters.IsoIntervalConverter } };
+            var interval = new Interval(Instant.FromUnixTimeTicks(1000L), Instant.FromUnixTimeTicks(20000L));
+            Assert.AreEqual(JsonSerializer.Serialize(interval, explicitOptions),
+                JsonSerializer.Serialize(interval, configuredOptions));
+        }
+
+        [Test]
+        public void Options_ConfigureForNodaTime_DefaultDateInterval()
+        {
+            var configuredOptions = new JsonSerializerOptions().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+            var explicitOptions = new JsonSerializerOptions
+            {
+                Converters = { NodaConverters.DateIntervalConverter, NodaConverters.LocalDateConverter }
+            };
+            var interval = new DateInterval(new LocalDate(2001, 2, 3), new LocalDate(2004, 5, 6));
+            Assert.AreEqual(JsonSerializer.Serialize(interval, explicitOptions),
+                JsonSerializer.Serialize(interval, configuredOptions));
+        }
+
+        [Test]
+        public void Options_ConfigureForNodaTime_WithIsoDateIntervalConverter()
+        {
+            var configuredOptions = new JsonSerializerOptions().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb).WithIsoDateIntervalConverter();
+            var explicitOptions = new JsonSerializerOptions { Converters = { NodaConverters.IsoDateIntervalConverter } };
+            var interval = new DateInterval(new LocalDate(2001, 2, 3), new LocalDate(2004, 5, 6));
+            Assert.AreEqual(JsonSerializer.Serialize(interval, explicitOptions),
+                JsonSerializer.Serialize(interval, configuredOptions));
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/NodaConverterBaseTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaConverterBaseTest.cs
@@ -36,7 +36,7 @@ namespace NodaTime.Serialization.Test.SystemText
                 Converters = { converter }
             };
 
-            JsonSerializer.Serialize(null, options);
+            JsonSerializer.Serialize((object)null, options);
         }
 
         [Test]
@@ -50,7 +50,6 @@ namespace NodaTime.Serialization.Test.SystemText
             };
 
             Assert.IsNull(JsonSerializer.Deserialize<int?>("null", options));
-            Assert.IsNull(JsonSerializer.Deserialize<int?>("\"\"", options));
         }
 
         [Test]
@@ -64,7 +63,6 @@ namespace NodaTime.Serialization.Test.SystemText
             };
 
             Assert.IsNull(JsonSerializer.Deserialize<string>("null", options));
-            Assert.IsNull(JsonSerializer.Deserialize<string>("\"\"", options));
         }
 
         [Test]
@@ -90,8 +88,8 @@ namespace NodaTime.Serialization.Test.SystemText
                 Converters = { converter }
             };
 
-            Assert.Throws<InvalidNodaDataException>(() => JsonSerializer.Deserialize<int>("null", options));
-            Assert.Throws<InvalidNodaDataException>(() => JsonSerializer.Deserialize<int>("\"\"", options));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("null", options));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("\"\"", options));
         }
 
         [Test]
@@ -105,31 +103,6 @@ namespace NodaTime.Serialization.Test.SystemText
             };
 
             Assert.AreEqual(5, JsonSerializer.Deserialize<int>("\"5\"", options));
-        }
-
-        [Test]
-        public void CanConvert_ValidValues()
-        {
-            var converter = new TestConverter();
-
-            Assert.IsTrue(converter.CanConvert(typeof(int)));
-            Assert.IsTrue(converter.CanConvert(typeof(int?)));
-        }
-
-        [Test]
-        public void CanConvert_InvalidValues()
-        {
-            var converter = new TestConverter();
-
-            Assert.IsFalse(converter.CanConvert(typeof(uint)));
-        }
-
-        [Test]
-        public void CanConvert_Inheritance()
-        {
-            var converter = new TestInheritanceConverter();
-
-            Assert.IsTrue(converter.CanConvert(typeof(MemoryStream)));
         }
 
         private class TestConverter : NodaConverterBase<int>
@@ -155,22 +128,6 @@ namespace NodaTime.Serialization.Test.SystemText
             protected override void WriteJsonImpl(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
             {
                 writer.WriteStringValue(value);
-            }
-        }
-
-        /// <summary>
-        /// Just use for CanConvert testing...
-        /// </summary>
-        private class TestInheritanceConverter : NodaConverterBase<Stream>
-        {
-            protected override Stream ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-
-            protected override void WriteJsonImpl(Utf8JsonWriter writer, Stream value, JsonSerializerOptions options)
-            {
-                throw new NotImplementedException();
             }
         }
     }

--- a/src/NodaTime.Serialization.Test/SystemText/NodaConverterBaseTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaConverterBaseTest.cs
@@ -1,0 +1,177 @@
+// Copyright 2019 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using NodaTime.Serialization.SystemText;
+using NodaTime.Utility;
+using NUnit.Framework;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    public class NodaConverterBaseTest
+    {
+        [Test]
+        public void Serialize_NonNullValue()
+        {
+            var converter = new TestConverter();
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                Converters = { converter }
+            };
+
+            JsonSerializer.Serialize(5, options);
+        }
+
+        [Test]
+        public void Serialize_NullValue()
+        {
+            var converter = new TestConverter();
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                Converters = { converter }
+            };
+
+            JsonSerializer.Serialize(null, options);
+        }
+
+        [Test]
+        public void Deserialize_NullableType_NullValue()
+        {
+            var converter = new TestConverter();
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                Converters = { converter }
+            };
+
+            Assert.IsNull(JsonSerializer.Deserialize<int?>("null", options));
+            Assert.IsNull(JsonSerializer.Deserialize<int?>("\"\"", options));
+        }
+
+        [Test]
+        public void Deserialize_ReferenceType_NullValue()
+        {
+            var converter = new TestStringConverter();
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                Converters = { converter }
+            };
+
+            Assert.IsNull(JsonSerializer.Deserialize<string>("null", options));
+            Assert.IsNull(JsonSerializer.Deserialize<string>("\"\"", options));
+        }
+
+        [Test]
+        public void Deserialize_NullableType_NonNullValue()
+        {
+            var converter = new TestConverter();
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                Converters = { converter }
+            };
+
+            Assert.AreEqual(5, JsonSerializer.Deserialize<int?>("\"5\"", options));
+        }
+
+        [Test]
+        public void Deserialize_NonNullableType_NullValue()
+        {
+            var converter = new TestConverter();
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                Converters = { converter }
+            };
+
+            Assert.Throws<InvalidNodaDataException>(() => JsonSerializer.Deserialize<int>("null", options));
+            Assert.Throws<InvalidNodaDataException>(() => JsonSerializer.Deserialize<int>("\"\"", options));
+        }
+
+        [Test]
+        public void Deserialize_NonNullableType_NonNullValue()
+        {
+            var converter = new TestConverter();
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                Converters = { converter }
+            };
+
+            Assert.AreEqual(5, JsonSerializer.Deserialize<int>("\"5\"", options));
+        }
+
+        [Test]
+        public void CanConvert_ValidValues()
+        {
+            var converter = new TestConverter();
+
+            Assert.IsTrue(converter.CanConvert(typeof(int)));
+            Assert.IsTrue(converter.CanConvert(typeof(int?)));
+        }
+
+        [Test]
+        public void CanConvert_InvalidValues()
+        {
+            var converter = new TestConverter();
+
+            Assert.IsFalse(converter.CanConvert(typeof(uint)));
+        }
+
+        [Test]
+        public void CanConvert_Inheritance()
+        {
+            var converter = new TestInheritanceConverter();
+
+            Assert.IsTrue(converter.CanConvert(typeof(MemoryStream)));
+        }
+
+        private class TestConverter : NodaConverterBase<int>
+        {
+            protected override int ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
+            {
+                return int.Parse(reader.GetString());
+            }
+
+            protected override void WriteJsonImpl(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.ToString());
+            }
+        }
+
+        private class TestStringConverter : NodaConverterBase<string>
+        {
+            protected override string ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
+            {
+                return reader.GetString();
+            }
+
+            protected override void WriteJsonImpl(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value);
+            }
+        }
+
+        /// <summary>
+        /// Just use for CanConvert testing...
+        /// </summary>
+        private class TestInheritanceConverter : NodaConverterBase<Stream>
+        {
+            protected override Stream ReadJsonImpl(ref Utf8JsonReader reader, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void WriteJsonImpl(Utf8JsonWriter writer, Stream value, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/NodaConvertersTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaConvertersTest.cs
@@ -1,0 +1,216 @@
+// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using NodaTime.Serialization.SystemText;
+using NUnit.Framework;
+using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    /// <summary>
+    /// Tests for the converters exposed in NodaConverters.
+    /// </summary>
+    public class NodaConvertersTest
+    {
+        [Test]
+        public void OffsetConverter()
+        {
+            var value = Offset.FromHoursAndMinutes(5, 30);
+            string json = "\"+05:30\"";
+            AssertConversions(value, json, NodaConverters.OffsetConverter);
+        }
+
+        [Test]
+        public void InstantConverter()
+        {
+            var value = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            string json = "\"2012-01-02T03:04:05Z\"";
+            AssertConversions(value, json, NodaConverters.InstantConverter);
+        }
+
+        [Test]
+        public void InstantConverter_EquivalentToIsoDateTimeConverter()
+        {
+            var dateTime = new DateTime(2012, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var instant = Instant.FromDateTimeUtc(dateTime);
+            var jsonDateTime = JsonConvert.SerializeObject(dateTime, new IsoDateTimeConverter());
+            var jsonInstant = JsonConvert.SerializeObject(instant, Formatting.None, NodaConverters.InstantConverter);
+            Assert.AreEqual(jsonDateTime, jsonInstant);
+        }
+
+        [Test]
+        public void LocalDateConverter()
+        {
+            var value = new LocalDate(2012, 1, 2, CalendarSystem.Iso);
+            string json = "\"2012-01-02\"";
+            AssertConversions(value, json, NodaConverters.LocalDateConverter);
+        }
+
+        [Test]
+        public void LocalDateConverter_SerializeNonIso_Throws()
+        {
+            var localDate = new LocalDate(2012, 1, 2, CalendarSystem.Coptic);
+
+            Assert.Throws<ArgumentException>(() => JsonConvert.SerializeObject(localDate, Formatting.None, NodaConverters.LocalDateConverter));
+        }
+
+        [Test]
+        public void LocalDateTimeConverter()
+        {
+            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5, CalendarSystem.Iso).PlusNanoseconds(123456789);
+            var json = "\"2012-01-02T03:04:05.123456789\"";
+            AssertConversions(value, json, NodaConverters.LocalDateTimeConverter);
+        }
+
+        [Test]
+        public void LocalDateTimeConverter_EquivalentToIsoDateTimeConverter()
+        {
+            var dateTime = new DateTime(2012, 1, 2, 3, 4, 5, 6, DateTimeKind.Unspecified);
+            var localDateTime = new LocalDateTime(2012, 1, 2, 3, 4, 5, 6, CalendarSystem.Iso);
+
+            var jsonDateTime = JsonConvert.SerializeObject(dateTime, new IsoDateTimeConverter());
+            var jsonLocalDateTime = JsonConvert.SerializeObject(localDateTime, Formatting.None, NodaConverters.LocalDateTimeConverter);
+
+            Assert.AreEqual(jsonDateTime, jsonLocalDateTime);
+        }
+
+        [Test]
+        public void LocalDateTimeConverter_SerializeNonIso_Throws()
+        {
+            var localDateTime = new LocalDateTime(2012, 1, 2, 3, 4, 5, CalendarSystem.Coptic);
+
+            Assert.Throws<ArgumentException>(() => JsonConvert.SerializeObject(localDateTime, Formatting.None, NodaConverters.LocalDateTimeConverter));
+        }
+
+        [Test]
+        public void LocalTimeConverter()
+        {
+            var value = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5).PlusNanoseconds(67);
+            var json = "\"01:02:03.004000567\"";
+            AssertConversions(value, json, NodaConverters.LocalTimeConverter);
+        }
+
+        [Test]
+        public void RoundtripPeriodConverter()
+        {
+            var value = Period.FromDays(2) + Period.FromHours(3) + Period.FromMinutes(90);
+            string json = "\"P2DT3H90M\"";
+            AssertConversions(value, json, NodaConverters.RoundtripPeriodConverter);
+        }
+
+        [Test]
+        public void NormalizingIsoPeriodConverter_RequiresNormalization()
+        {
+            // Can't use AssertConversions here, as it doesn't round-trip
+            var period = Period.FromDays(2) + Period.FromHours(3) + Period.FromMinutes(90);
+            var json = JsonConvert.SerializeObject(period, Formatting.None, NodaConverters.NormalizingIsoPeriodConverter);
+            string expectedJson = "\"P2DT4H30M\"";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void NormalizingIsoPeriodConverter_AlreadyNormalized()
+        {
+            // This time we're okay as it's already a normalized value.
+            var value = Period.FromDays(2) + Period.FromHours(4) + Period.FromMinutes(30);
+            string json = "\"P2DT4H30M\"";
+            AssertConversions(value, json, NodaConverters.NormalizingIsoPeriodConverter);
+        }
+
+        [Test]
+        public void ZonedDateTimeConverter()
+        {
+            // Deliberately give it an ambiguous local time, in both ways.
+            var zone = DateTimeZoneProviders.Tzdb["Europe/London"];
+            var earlierValue = new ZonedDateTime(new LocalDateTime(2012, 10, 28, 1, 30), zone, Offset.FromHours(1));
+            var laterValue = new ZonedDateTime(new LocalDateTime(2012, 10, 28, 1, 30), zone, Offset.FromHours(0));
+            string earlierJson = "\"2012-10-28T01:30:00+01 Europe/London\"";
+            string laterJson = "\"2012-10-28T01:30:00Z Europe/London\"";
+            var converter = NodaConverters.CreateZonedDateTimeConverter(DateTimeZoneProviders.Tzdb);
+
+            AssertConversions(earlierValue, earlierJson, converter);
+            AssertConversions(laterValue, laterJson, converter);
+        }
+
+        [Test]
+        public void OffsetDateTimeConverter()
+        {
+            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5).PlusNanoseconds(123456789).WithOffset(Offset.FromHoursAndMinutes(-1, -30));
+            string json = "\"2012-01-02T03:04:05.123456789-01:30\"";
+            AssertConversions(value, json, NodaConverters.OffsetDateTimeConverter);
+        }
+
+        [Test]
+        public void OffsetDateTimeConverter_WholeHours()
+        {
+            // Redundantly specify the minutes, so that Javascript can parse it and it's RFC3339-compliant.
+            // See issue 284 for details.
+            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5).PlusNanoseconds(123456789).WithOffset(Offset.FromHours(5));
+            string json = "\"2012-01-02T03:04:05.123456789+05:00\"";
+            AssertConversions(value, json, NodaConverters.OffsetDateTimeConverter);
+        }
+
+        [Test]
+        public void OffsetDateTimeConverter_ZeroOffset()
+        {
+            // Redundantly specify the minutes, so that Javascript can parse it and it's RFC3339-compliant.
+            // See issue 284 for details.
+            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5).PlusNanoseconds(123456789).WithOffset(Offset.Zero);
+            string json = "\"2012-01-02T03:04:05.123456789Z\"";
+            AssertConversions(value, json, NodaConverters.OffsetDateTimeConverter);
+        }
+
+        [Test]
+        public void Duration_WholeSeconds()
+        {
+            AssertConversions(Duration.FromHours(48), "\"48:00:00\"", NodaConverters.DurationConverter);
+        }
+
+        [Test]
+        public void Duration_FractionalSeconds()
+        {
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromNanoseconds(123456789), "\"48:00:03.123456789\"", NodaConverters.DurationConverter);
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromTicks(1230000), "\"48:00:03.123\"", NodaConverters.DurationConverter);
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromTicks(1234000), "\"48:00:03.1234\"", NodaConverters.DurationConverter);
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromTicks(12345), "\"48:00:03.0012345\"", NodaConverters.DurationConverter);
+        }
+
+        [Test]
+        public void Duration_MinAndMaxValues()
+        {
+            AssertConversions(Duration.FromTicks(long.MaxValue), "\"256204778:48:05.4775807\"", NodaConverters.DurationConverter);
+            AssertConversions(Duration.FromTicks(long.MinValue), "\"-256204778:48:05.4775808\"", NodaConverters.DurationConverter);
+        }
+
+        /// <summary>
+        /// The pre-release converter used either 3 or 7 decimal places for fractions of a second; never less.
+        /// This test checks that the "new" converter (using DurationPattern) can still parse the old output.
+        /// </summary>
+        [Test]
+        public void Duration_ParsePartialFractionalSecondsWithTrailingZeroes()
+        {
+            var parsed = JsonConvert.DeserializeObject<Duration>("\"25:10:00.1234000\"", NodaConverters.DurationConverter);
+            Assert.AreEqual(Duration.FromHours(25) + Duration.FromMinutes(10) + Duration.FromTicks(1234000), parsed);
+        }
+
+        [Test]
+        public void OffsetDateConverter()
+        {
+            var value = new LocalDate(2012, 1, 2).WithOffset(Offset.FromHoursAndMinutes(-1, -30));
+            string json = "\"2012-01-02-01:30\"";
+            AssertConversions(value, json, NodaConverters.OffsetDateConverter);
+        }
+
+        [Test]
+        public void OffsetTimeConverter()
+        {
+            var value = new LocalTime(3, 4, 5).PlusNanoseconds(123456789).WithOffset(Offset.FromHoursAndMinutes(-1, -30));
+            string json = "\"03:04:05.123456789-01:30\"";
+            AssertConversions(value, json, NodaConverters.OffsetTimeConverter);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/NodaDateIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaDateIntervalConverterTest.cs
@@ -1,0 +1,111 @@
+// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NodaTime.Serialization.SystemText;
+using NUnit.Framework;
+using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    public class NodaDateIntervalConverterTest
+    {
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        {
+            Converters = { NodaConverters.DateIntervalConverter, NodaConverters.LocalDateConverter },
+            DateParseHandling = DateParseHandling.None
+        };
+
+        private readonly JsonSerializerSettings settingsCamelCase = new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Converters = { NodaConverters.DateIntervalConverter, NodaConverters.LocalDateConverter },
+            DateParseHandling = DateParseHandling.None
+        };
+
+        [Test]
+        public void RoundTrip()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+            AssertConversions(dateInterval, "{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}", settings);
+        }
+
+        [Test]
+        public void RoundTrip_CamelCase()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+            AssertConversions(dateInterval, "{\"start\":\"2012-01-02\",\"end\":\"2013-06-07\"}", settingsCamelCase);
+        }
+
+        [Test]
+        public void Serialize_InObject()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+
+            var testObject = new TestObject { Interval = dateInterval };
+
+            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+
+            string expectedJson = "{\"Interval\":{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Serialize_InObject_CamelCase()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+
+            var testObject = new TestObject { Interval = dateInterval };
+
+            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settingsCamelCase);
+
+            string expectedJson = "{\"interval\":{\"start\":\"2012-01-02\",\"end\":\"2013-06-07\"}}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Deserialize_InObject()
+        {
+            string json = "{\"Interval\":{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}}";
+
+            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+
+            var interval = testObject.Interval;
+
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var expectedInterval = new DateInterval(startLocalDate, endLocalDate);
+            Assert.AreEqual(expectedInterval, interval);
+        }
+
+        [Test]
+        public void Deserialize_InObject_CamelCase()
+        {
+            string json = "{\"interval\":{\"start\":\"2012-01-02\",\"end\":\"2013-06-07\"}}";
+
+            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settingsCamelCase);
+
+            var interval = testObject.Interval;
+
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var expectedInterval = new DateInterval(startLocalDate, endLocalDate);
+            Assert.AreEqual(expectedInterval, interval);
+        }
+
+        public class TestObject
+        {
+            public DateInterval Interval { get; set; }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/NodaDateIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaDateIntervalConverterTest.cs
@@ -1,28 +1,25 @@
-// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
 using NodaTime.Serialization.SystemText;
 using NUnit.Framework;
-using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+using static NodaTime.Serialization.Test.SystemText.TestHelper;
 
 namespace NodaTime.Serialization.Test.SystemText
 {
     public class NodaDateIntervalConverterTest
     {
-        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        private readonly JsonSerializerOptions options = new JsonSerializerOptions
         {
             Converters = { NodaConverters.DateIntervalConverter, NodaConverters.LocalDateConverter },
-            DateParseHandling = DateParseHandling.None
         };
 
-        private readonly JsonSerializerSettings settingsCamelCase = new JsonSerializerSettings
+        private readonly JsonSerializerOptions optionsCamelCase = new JsonSerializerOptions
         {
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             Converters = { NodaConverters.DateIntervalConverter, NodaConverters.LocalDateConverter },
-            DateParseHandling = DateParseHandling.None
         };
 
         [Test]
@@ -31,7 +28,7 @@ namespace NodaTime.Serialization.Test.SystemText
             var startLocalDate = new LocalDate(2012, 1, 2);
             var endLocalDate = new LocalDate(2013, 6, 7);
             var dateInterval = new DateInterval(startLocalDate, endLocalDate);
-            AssertConversions(dateInterval, "{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}", settings);
+            AssertConversions(dateInterval, "{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}", options);
         }
 
         [Test]
@@ -40,7 +37,7 @@ namespace NodaTime.Serialization.Test.SystemText
             var startLocalDate = new LocalDate(2012, 1, 2);
             var endLocalDate = new LocalDate(2013, 6, 7);
             var dateInterval = new DateInterval(startLocalDate, endLocalDate);
-            AssertConversions(dateInterval, "{\"start\":\"2012-01-02\",\"end\":\"2013-06-07\"}", settingsCamelCase);
+            AssertConversions(dateInterval, "{\"start\":\"2012-01-02\",\"end\":\"2013-06-07\"}", optionsCamelCase);
         }
 
         [Test]
@@ -52,7 +49,7 @@ namespace NodaTime.Serialization.Test.SystemText
 
             var testObject = new TestObject { Interval = dateInterval };
 
-            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+            var json = JsonSerializer.Serialize(testObject, options);
 
             string expectedJson = "{\"Interval\":{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}}";
             Assert.AreEqual(expectedJson, json);
@@ -67,7 +64,7 @@ namespace NodaTime.Serialization.Test.SystemText
 
             var testObject = new TestObject { Interval = dateInterval };
 
-            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settingsCamelCase);
+            var json = JsonSerializer.Serialize(testObject, optionsCamelCase);
 
             string expectedJson = "{\"interval\":{\"start\":\"2012-01-02\",\"end\":\"2013-06-07\"}}";
             Assert.AreEqual(expectedJson, json);
@@ -78,7 +75,7 @@ namespace NodaTime.Serialization.Test.SystemText
         {
             string json = "{\"Interval\":{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}}";
 
-            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, options);
 
             var interval = testObject.Interval;
 
@@ -93,7 +90,7 @@ namespace NodaTime.Serialization.Test.SystemText
         {
             string json = "{\"interval\":{\"start\":\"2012-01-02\",\"end\":\"2013-06-07\"}}";
 
-            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settingsCamelCase);
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, optionsCamelCase);
 
             var interval = testObject.Interval;
 

--- a/src/NodaTime.Serialization.Test/SystemText/NodaDateTimeZoneConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaDateTimeZoneConverterTest.cs
@@ -1,23 +1,31 @@
-// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-using Newtonsoft.Json;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using NodaTime.Serialization.SystemText;
 using NodaTime.TimeZones;
 using NUnit.Framework;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace NodaTime.Serialization.Test.SystemText
 {
     public class NodaDateTimeZoneConverterTest
     {
-        private readonly JsonConverter converter = NodaConverters.CreateDateTimeZoneConverter(DateTimeZoneProviders.Tzdb);
+        private readonly JsonConverter<DateTimeZone> converter =
+            NodaConverters.CreateDateTimeZoneConverter(DateTimeZoneProviders.Tzdb);
 
         [Test]
         public void Serialize()
         {
             var dateTimeZone = DateTimeZoneProviders.Tzdb["America/Los_Angeles"];
-            var json = JsonConvert.SerializeObject(dateTimeZone, Formatting.None, converter);
+            var json = JsonSerializer.Serialize(dateTimeZone, new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                Converters = {converter}
+            });
             string expectedJson = "\"America/Los_Angeles\"";
             Assert.AreEqual(expectedJson, json);
         }
@@ -26,7 +34,10 @@ namespace NodaTime.Serialization.Test.SystemText
         public void Deserialize()
         {
             string json = "\"America/Los_Angeles\"";
-            var dateTimeZone = JsonConvert.DeserializeObject<DateTimeZone>(json, converter);
+            var dateTimeZone = JsonSerializer.Deserialize<DateTimeZone>(json, new JsonSerializerOptions
+            {
+                Converters = {converter}
+            });
             var expectedDateTimeZone = DateTimeZoneProviders.Tzdb["America/Los_Angeles"];
             Assert.AreEqual(expectedDateTimeZone, dateTimeZone);
         }
@@ -35,7 +46,12 @@ namespace NodaTime.Serialization.Test.SystemText
         public void Deserialize_TimeZoneNotFound()
         {
             string json = "\"America/DOES_NOT_EXIST\"";
-            var exception = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DateTimeZone>(json, converter));
+            var exception =
+                Assert.Throws<SerializationException>(() =>
+                    JsonSerializer.Deserialize<DateTimeZone>(json, new JsonSerializerOptions
+                    {
+                        Converters = {converter}
+                    }));
             Assert.IsInstanceOf<DateTimeZoneNotFoundException>(exception.InnerException);
         }
     }

--- a/src/NodaTime.Serialization.Test/SystemText/NodaDateTimeZoneConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaDateTimeZoneConverterTest.cs
@@ -1,0 +1,42 @@
+// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Newtonsoft.Json;
+using NodaTime.Serialization.SystemText;
+using NodaTime.TimeZones;
+using NUnit.Framework;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    public class NodaDateTimeZoneConverterTest
+    {
+        private readonly JsonConverter converter = NodaConverters.CreateDateTimeZoneConverter(DateTimeZoneProviders.Tzdb);
+
+        [Test]
+        public void Serialize()
+        {
+            var dateTimeZone = DateTimeZoneProviders.Tzdb["America/Los_Angeles"];
+            var json = JsonConvert.SerializeObject(dateTimeZone, Formatting.None, converter);
+            string expectedJson = "\"America/Los_Angeles\"";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Deserialize()
+        {
+            string json = "\"America/Los_Angeles\"";
+            var dateTimeZone = JsonConvert.DeserializeObject<DateTimeZone>(json, converter);
+            var expectedDateTimeZone = DateTimeZoneProviders.Tzdb["America/Los_Angeles"];
+            Assert.AreEqual(expectedDateTimeZone, dateTimeZone);
+        }
+
+        [Test]
+        public void Deserialize_TimeZoneNotFound()
+        {
+            string json = "\"America/DOES_NOT_EXIST\"";
+            var exception = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DateTimeZone>(json, converter));
+            Assert.IsInstanceOf<DateTimeZoneNotFoundException>(exception.InnerException);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/NodaDateTimeZoneConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaDateTimeZoneConverterTest.cs
@@ -47,7 +47,7 @@ namespace NodaTime.Serialization.Test.SystemText
         {
             string json = "\"America/DOES_NOT_EXIST\"";
             var exception =
-                Assert.Throws<SerializationException>(() =>
+                Assert.Throws<JsonException>(() =>
                     JsonSerializer.Deserialize<DateTimeZone>(json, new JsonSerializerOptions
                     {
                         Converters = {converter}

--- a/src/NodaTime.Serialization.Test/SystemText/NodaInstantConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaInstantConverterTest.cs
@@ -1,0 +1,84 @@
+// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using NodaTime.Serialization.SystemText;
+using NUnit.Framework;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    public class NodaInstantConverterTest
+    {
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        {
+            Converters = { NodaConverters.InstantConverter },
+            DateParseHandling = DateParseHandling.None
+        };
+
+        [Test]
+        public void Serialize_NonNullableType()
+        {
+            var instant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var json = JsonConvert.SerializeObject(instant, Formatting.None, settings);
+            string expectedJson = "\"2012-01-02T03:04:05Z\"";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Serialize_NullableType_NonNullValue()
+        {
+            Instant? instant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var json = JsonConvert.SerializeObject(instant, Formatting.None, settings);
+            string expectedJson = "\"2012-01-02T03:04:05Z\"";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Serialize_NullableType_NullValue()
+        {
+            Instant? instant = null;
+            var json = JsonConvert.SerializeObject(instant, Formatting.None, settings);
+            string expectedJson = "null";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Deserialize_ToNonNullableType()
+        {
+            string json = "\"2012-01-02T03:04:05Z\"";
+            var instant = JsonConvert.DeserializeObject<Instant>(json, settings);
+            var expectedInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            Assert.AreEqual(expectedInstant, instant);
+        }
+
+        [Test]
+        public void Deserialize_ToNullableType_NonNullValue()
+        {
+            string json = "\"2012-01-02T03:04:05Z\"";
+            var instant = JsonConvert.DeserializeObject<Instant?>(json, settings);
+            Instant? expectedInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            Assert.AreEqual(expectedInstant, instant);
+        }
+
+        [Test]
+        public void Deserialize_ToNullableType_NullValue()
+        {
+            string json = "null";
+            var instant = JsonConvert.DeserializeObject<Instant?>(json, settings);
+            Assert.IsNull(instant);
+        }
+
+        [Test]
+        public void Serialize_EquivalentToIsoDateTimeConverter()
+        {
+            var dateTime = new DateTime(2012, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var instant = Instant.FromDateTimeUtc(dateTime);
+            var jsonDateTime = JsonConvert.SerializeObject(dateTime, new IsoDateTimeConverter());
+            var jsonInstant = JsonConvert.SerializeObject(instant, Formatting.None, settings);
+            Assert.AreEqual(jsonDateTime, jsonInstant);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/NodaInstantConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaInstantConverterTest.cs
@@ -1,10 +1,9 @@
-// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
 using System;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json;
 using NodaTime.Serialization.SystemText;
 using NUnit.Framework;
 
@@ -12,17 +11,16 @@ namespace NodaTime.Serialization.Test.SystemText
 {
     public class NodaInstantConverterTest
     {
-        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        private readonly JsonSerializerOptions options = new JsonSerializerOptions
         {
             Converters = { NodaConverters.InstantConverter },
-            DateParseHandling = DateParseHandling.None
         };
 
         [Test]
         public void Serialize_NonNullableType()
         {
             var instant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
-            var json = JsonConvert.SerializeObject(instant, Formatting.None, settings);
+            var json = JsonSerializer.Serialize(instant, options);
             string expectedJson = "\"2012-01-02T03:04:05Z\"";
             Assert.AreEqual(expectedJson, json);
         }
@@ -31,7 +29,7 @@ namespace NodaTime.Serialization.Test.SystemText
         public void Serialize_NullableType_NonNullValue()
         {
             Instant? instant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
-            var json = JsonConvert.SerializeObject(instant, Formatting.None, settings);
+            var json = JsonSerializer.Serialize(instant, options);
             string expectedJson = "\"2012-01-02T03:04:05Z\"";
             Assert.AreEqual(expectedJson, json);
         }
@@ -40,7 +38,7 @@ namespace NodaTime.Serialization.Test.SystemText
         public void Serialize_NullableType_NullValue()
         {
             Instant? instant = null;
-            var json = JsonConvert.SerializeObject(instant, Formatting.None, settings);
+            var json = JsonSerializer.Serialize(instant, options);
             string expectedJson = "null";
             Assert.AreEqual(expectedJson, json);
         }
@@ -49,7 +47,7 @@ namespace NodaTime.Serialization.Test.SystemText
         public void Deserialize_ToNonNullableType()
         {
             string json = "\"2012-01-02T03:04:05Z\"";
-            var instant = JsonConvert.DeserializeObject<Instant>(json, settings);
+            var instant = JsonSerializer.Deserialize<Instant>(json, options);
             var expectedInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
             Assert.AreEqual(expectedInstant, instant);
         }
@@ -58,7 +56,7 @@ namespace NodaTime.Serialization.Test.SystemText
         public void Deserialize_ToNullableType_NonNullValue()
         {
             string json = "\"2012-01-02T03:04:05Z\"";
-            var instant = JsonConvert.DeserializeObject<Instant?>(json, settings);
+            var instant = JsonSerializer.Deserialize<Instant?>(json, options);
             Instant? expectedInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
             Assert.AreEqual(expectedInstant, instant);
         }
@@ -67,7 +65,7 @@ namespace NodaTime.Serialization.Test.SystemText
         public void Deserialize_ToNullableType_NullValue()
         {
             string json = "null";
-            var instant = JsonConvert.DeserializeObject<Instant?>(json, settings);
+            var instant = JsonSerializer.Deserialize<Instant?>(json, options);
             Assert.IsNull(instant);
         }
 
@@ -76,8 +74,8 @@ namespace NodaTime.Serialization.Test.SystemText
         {
             var dateTime = new DateTime(2012, 1, 2, 3, 4, 5, DateTimeKind.Utc);
             var instant = Instant.FromDateTimeUtc(dateTime);
-            var jsonDateTime = JsonConvert.SerializeObject(dateTime, new IsoDateTimeConverter());
-            var jsonInstant = JsonConvert.SerializeObject(instant, Formatting.None, settings);
+            var jsonDateTime = JsonSerializer.Serialize(instant, options);
+            var jsonInstant = JsonSerializer.Serialize(instant, options);
             Assert.AreEqual(jsonDateTime, jsonInstant);
         }
     }

--- a/src/NodaTime.Serialization.Test/SystemText/NodaIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaIntervalConverterTest.cs
@@ -1,29 +1,25 @@
-// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
 using NodaTime.Serialization.SystemText;
 using NUnit.Framework;
-using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+using static NodaTime.Serialization.Test.SystemText.TestHelper;
 
 namespace NodaTime.Serialization.Test.SystemText
 {
     public class NodaIntervalConverterTest
     {
-        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        private readonly JsonSerializerOptions options = new JsonSerializerOptions
         {
-            ContractResolver = new DefaultContractResolver(),
             Converters = { NodaConverters.IntervalConverter, NodaConverters.InstantConverter },
-            DateParseHandling = DateParseHandling.None
         };
 
-        private readonly JsonSerializerSettings settingsCamelCase = new JsonSerializerSettings
+        private readonly JsonSerializerOptions optionsCamelCase = new JsonSerializerOptions
         {
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             Converters = { NodaConverters.IntervalConverter, NodaConverters.InstantConverter },
-            DateParseHandling = DateParseHandling.None
         };
 
         [Test]
@@ -32,16 +28,16 @@ namespace NodaTime.Serialization.Test.SystemText
             var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5) + Duration.FromMilliseconds(670);
             var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10) + Duration.FromNanoseconds(123456789);
             var interval = new Interval(startInstant, endInstant);
-            AssertConversions(interval, "{\"Start\":\"2012-01-02T03:04:05.67Z\",\"End\":\"2013-06-07T08:09:10.123456789Z\"}", settings);
+            AssertConversions(interval, "{\"Start\":\"2012-01-02T03:04:05.67Z\",\"End\":\"2013-06-07T08:09:10.123456789Z\"}", options);
         }
 
         [Test]
         public void RoundTrip_Infinite()
         {
             var instant = Instant.FromUtc(2013, 6, 7, 8, 9, 10) + Duration.FromNanoseconds(123456789);
-            AssertConversions(new Interval(null, instant), "{\"End\":\"2013-06-07T08:09:10.123456789Z\"}", settings);
-            AssertConversions(new Interval(instant, null), "{\"Start\":\"2013-06-07T08:09:10.123456789Z\"}", settings);
-            AssertConversions(new Interval(null, null), "{}", settings);
+            AssertConversions(new Interval(null, instant), "{\"End\":\"2013-06-07T08:09:10.123456789Z\"}", options);
+            AssertConversions(new Interval(instant, null), "{\"Start\":\"2013-06-07T08:09:10.123456789Z\"}", options);
+            AssertConversions(new Interval(null, null), "{}", options);
         }
 
         [Test]
@@ -53,7 +49,7 @@ namespace NodaTime.Serialization.Test.SystemText
 
             var testObject = new TestObject { Interval = interval };
 
-            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+            var json = JsonSerializer.Serialize(testObject, options);
 
             string expectedJson = "{\"Interval\":{\"Start\":\"2012-01-02T03:04:05Z\",\"End\":\"2013-06-07T08:09:10Z\"}}";
             Assert.AreEqual(expectedJson, json);
@@ -68,7 +64,7 @@ namespace NodaTime.Serialization.Test.SystemText
 
             var testObject = new TestObject { Interval = interval };
 
-            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settingsCamelCase);
+            var json = JsonSerializer.Serialize(testObject, optionsCamelCase);
 
             string expectedJson = "{\"interval\":{\"start\":\"2012-01-02T03:04:05Z\",\"end\":\"2013-06-07T08:09:10Z\"}}";
             Assert.AreEqual(expectedJson, json);
@@ -79,7 +75,7 @@ namespace NodaTime.Serialization.Test.SystemText
         {
             string json = "{\"Interval\":{\"Start\":\"2012-01-02T03:04:05Z\",\"End\":\"2013-06-07T08:09:10Z\"}}";
 
-            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, options);
 
             var interval = testObject.Interval;
 
@@ -94,7 +90,7 @@ namespace NodaTime.Serialization.Test.SystemText
         {
             string json = "{\"interval\":{\"start\":\"2012-01-02T03:04:05Z\",\"end\":\"2013-06-07T08:09:10Z\"}}";
 
-            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settingsCamelCase);
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, optionsCamelCase);
 
             var interval = testObject.Interval;
 

--- a/src/NodaTime.Serialization.Test/SystemText/NodaIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaIntervalConverterTest.cs
@@ -1,0 +1,112 @@
+// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NodaTime.Serialization.SystemText;
+using NUnit.Framework;
+using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    public class NodaIntervalConverterTest
+    {
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        {
+            ContractResolver = new DefaultContractResolver(),
+            Converters = { NodaConverters.IntervalConverter, NodaConverters.InstantConverter },
+            DateParseHandling = DateParseHandling.None
+        };
+
+        private readonly JsonSerializerSettings settingsCamelCase = new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Converters = { NodaConverters.IntervalConverter, NodaConverters.InstantConverter },
+            DateParseHandling = DateParseHandling.None
+        };
+
+        [Test]
+        public void RoundTrip()
+        {
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5) + Duration.FromMilliseconds(670);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10) + Duration.FromNanoseconds(123456789);
+            var interval = new Interval(startInstant, endInstant);
+            AssertConversions(interval, "{\"Start\":\"2012-01-02T03:04:05.67Z\",\"End\":\"2013-06-07T08:09:10.123456789Z\"}", settings);
+        }
+
+        [Test]
+        public void RoundTrip_Infinite()
+        {
+            var instant = Instant.FromUtc(2013, 6, 7, 8, 9, 10) + Duration.FromNanoseconds(123456789);
+            AssertConversions(new Interval(null, instant), "{\"End\":\"2013-06-07T08:09:10.123456789Z\"}", settings);
+            AssertConversions(new Interval(instant, null), "{\"Start\":\"2013-06-07T08:09:10.123456789Z\"}", settings);
+            AssertConversions(new Interval(null, null), "{}", settings);
+        }
+
+        [Test]
+        public void Serialize_InObject()
+        {
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var interval = new Interval(startInstant, endInstant);
+
+            var testObject = new TestObject { Interval = interval };
+
+            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+
+            string expectedJson = "{\"Interval\":{\"Start\":\"2012-01-02T03:04:05Z\",\"End\":\"2013-06-07T08:09:10Z\"}}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Serialize_InObject_CamelCase()
+        {
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var interval = new Interval(startInstant, endInstant);
+
+            var testObject = new TestObject { Interval = interval };
+
+            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settingsCamelCase);
+
+            string expectedJson = "{\"interval\":{\"start\":\"2012-01-02T03:04:05Z\",\"end\":\"2013-06-07T08:09:10Z\"}}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Deserialize_InObject()
+        {
+            string json = "{\"Interval\":{\"Start\":\"2012-01-02T03:04:05Z\",\"End\":\"2013-06-07T08:09:10Z\"}}";
+
+            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+
+            var interval = testObject.Interval;
+
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var expectedInterval = new Interval(startInstant, endInstant);
+            Assert.AreEqual(expectedInterval, interval);
+        }
+
+        [Test]
+        public void Deserialize_InObject_CamelCase()
+        {
+            string json = "{\"interval\":{\"start\":\"2012-01-02T03:04:05Z\",\"end\":\"2013-06-07T08:09:10Z\"}}";
+
+            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settingsCamelCase);
+
+            var interval = testObject.Interval;
+
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var expectedInterval = new Interval(startInstant, endInstant);
+            Assert.AreEqual(expectedInterval, interval);
+        }
+
+        public class TestObject
+        {
+            public Interval Interval { get; set; }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/NodaIsoDateIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaIsoDateIntervalConverterTest.cs
@@ -1,11 +1,11 @@
-// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using NodaTime.Serialization.SystemText;
 using NUnit.Framework;
-using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+using static NodaTime.Serialization.Test.SystemText.TestHelper;
 
 namespace NodaTime.Serialization.Test.SystemText
 {
@@ -14,10 +14,9 @@ namespace NodaTime.Serialization.Test.SystemText
     /// </summary>
     public class NodaIsoDateIntervalConverterTest
     {
-        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        private readonly JsonSerializerOptions options = new JsonSerializerOptions
         {
             Converters = { NodaConverters.IsoDateIntervalConverter, NodaConverters.LocalDateConverter },
-            DateParseHandling = DateParseHandling.None
         };
 
         [Test]
@@ -26,14 +25,14 @@ namespace NodaTime.Serialization.Test.SystemText
             var startLocalDate = new LocalDate(2012, 1, 2);
             var endLocalDate = new LocalDate(2013, 6, 7);
             var dateInterval = new DateInterval(startLocalDate, endLocalDate);
-            AssertConversions(dateInterval, "\"2012-01-02/2013-06-07\"", settings);
+            AssertConversions(dateInterval, "\"2012-01-02/2013-06-07\"", options);
         }
 
         [Test]
         [TestCase("\"2012-01-022013-06-07\"")]
         public void InvalidJson(string json)
         {
-            AssertInvalidJson<DateInterval>(json, settings);
+            AssertInvalidJson<DateInterval>(json, options);
         }
 
         [Test]
@@ -45,7 +44,7 @@ namespace NodaTime.Serialization.Test.SystemText
 
             var testObject = new TestObject { Interval = dateInterval };
 
-            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+            var json = JsonSerializer.Serialize(testObject, options);
 
             string expectedJson = "{\"Interval\":\"2012-01-02/2013-06-07\"}";
             Assert.AreEqual(expectedJson, json);
@@ -56,7 +55,7 @@ namespace NodaTime.Serialization.Test.SystemText
         {
             string json = "{\"Interval\":\"2012-01-02/2013-06-07\"}";
 
-            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, options);
 
             var interval = testObject.Interval;
 

--- a/src/NodaTime.Serialization.Test/SystemText/NodaIsoDateIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaIsoDateIntervalConverterTest.cs
@@ -1,0 +1,74 @@
+// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Newtonsoft.Json;
+using NodaTime.Serialization.SystemText;
+using NUnit.Framework;
+using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    /// <summary>
+    /// The same tests as NodaDateIntervalConverterTest, but using the ISO-based interval converter.
+    /// </summary>
+    public class NodaIsoDateIntervalConverterTest
+    {
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        {
+            Converters = { NodaConverters.IsoDateIntervalConverter, NodaConverters.LocalDateConverter },
+            DateParseHandling = DateParseHandling.None
+        };
+
+        [Test]
+        public void RoundTrip()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+            AssertConversions(dateInterval, "\"2012-01-02/2013-06-07\"", settings);
+        }
+
+        [Test]
+        [TestCase("\"2012-01-022013-06-07\"")]
+        public void InvalidJson(string json)
+        {
+            AssertInvalidJson<DateInterval>(json, settings);
+        }
+
+        [Test]
+        public void Serialize_InObject()
+        {
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var dateInterval = new DateInterval(startLocalDate, endLocalDate);
+
+            var testObject = new TestObject { Interval = dateInterval };
+
+            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+
+            string expectedJson = "{\"Interval\":\"2012-01-02/2013-06-07\"}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Deserialize_InObject()
+        {
+            string json = "{\"Interval\":\"2012-01-02/2013-06-07\"}";
+
+            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+
+            var interval = testObject.Interval;
+
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var expectedInterval = new DateInterval(startLocalDate, endLocalDate);
+            Assert.AreEqual(expectedInterval, interval);
+        }
+
+        public class TestObject
+        {
+            public DateInterval Interval { get; set; }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/NodaIsoIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaIsoIntervalConverterTest.cs
@@ -1,11 +1,11 @@
-// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using NodaTime.Serialization.SystemText;
 using NUnit.Framework;
-using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+using static NodaTime.Serialization.Test.SystemText.TestHelper;
 
 namespace NodaTime.Serialization.Test.SystemText
 {
@@ -14,10 +14,9 @@ namespace NodaTime.Serialization.Test.SystemText
     /// </summary>
     public class NodaIsoIntervalConverterTest
     {
-        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        private readonly JsonSerializerOptions settings = new JsonSerializerOptions
         {
-            Converters = { NodaConverters.IsoIntervalConverter },
-            DateParseHandling = DateParseHandling.None
+            Converters = { NodaConverters.IsoIntervalConverter }
         };
 
         [Test]
@@ -44,7 +43,7 @@ namespace NodaTime.Serialization.Test.SystemText
             // Comma is deliberate, to show that we can parse a comma decimal separator too.
             string json = "\"2012-01-02T03:04:05.670Z/2013-06-07T08:09:10,1234567Z\"";
 
-            var interval = JsonConvert.DeserializeObject<Interval>(json, settings);
+            var interval = JsonSerializer.Deserialize<Interval>(json, settings);
 
             var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5) + Duration.FromMilliseconds(670);
             var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10) + Duration.FromTicks(1234567);
@@ -68,7 +67,7 @@ namespace NodaTime.Serialization.Test.SystemText
 
             var testObject = new TestObject { Interval = interval };
 
-            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+            var json = JsonSerializer.Serialize(testObject, settings);
 
             string expectedJson = "{\"Interval\":\"2012-01-02T03:04:05Z/2013-06-07T08:09:10Z\"}";
             Assert.AreEqual(expectedJson, json);
@@ -79,7 +78,7 @@ namespace NodaTime.Serialization.Test.SystemText
         {
             string json = "{\"Interval\":\"2012-01-02T03:04:05Z/2013-06-07T08:09:10Z\"}";
 
-            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, settings);
 
             var interval = testObject.Interval;
 

--- a/src/NodaTime.Serialization.Test/SystemText/NodaIsoIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/NodaIsoIntervalConverterTest.cs
@@ -1,0 +1,97 @@
+// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Newtonsoft.Json;
+using NodaTime.Serialization.SystemText;
+using NUnit.Framework;
+using static NodaTime.Serialization.Test.JsonNet.TestHelper;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    /// <summary>
+    /// The same tests as NodaIntervalConverterTest, but using the ISO-based interval converter.
+    /// </summary>
+    public class NodaIsoIntervalConverterTest
+    {
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings
+        {
+            Converters = { NodaConverters.IsoIntervalConverter },
+            DateParseHandling = DateParseHandling.None
+        };
+
+        [Test]
+        public void RoundTrip()
+        {
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5) + Duration.FromMilliseconds(670);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10) + Duration.FromNanoseconds(123456789);
+            var interval = new Interval(startInstant, endInstant);
+            AssertConversions(interval, "\"2012-01-02T03:04:05.67Z/2013-06-07T08:09:10.123456789Z\"", settings);
+        }
+
+        [Test]
+        public void RoundTrip_Infinite()
+        {
+            var instant = Instant.FromUtc(2013, 6, 7, 8, 9, 10) + Duration.FromNanoseconds(123456789);
+            AssertConversions(new Interval(null, instant), "\"/2013-06-07T08:09:10.123456789Z\"", settings);
+            AssertConversions(new Interval(instant, null), "\"2013-06-07T08:09:10.123456789Z/\"", settings);
+            AssertConversions(new Interval(null, null), "\"/\"", settings);
+        }
+
+        [Test]
+        public void DeserializeComma()
+        {
+            // Comma is deliberate, to show that we can parse a comma decimal separator too.
+            string json = "\"2012-01-02T03:04:05.670Z/2013-06-07T08:09:10,1234567Z\"";
+
+            var interval = JsonConvert.DeserializeObject<Interval>(json, settings);
+
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5) + Duration.FromMilliseconds(670);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10) + Duration.FromTicks(1234567);
+            var expectedInterval = new Interval(startInstant, endInstant);
+            Assert.AreEqual(expectedInterval, interval);
+        }
+
+        [Test]
+        [TestCase("\"2012-01-02T03:04:05Z2013-06-07T08:09:10Z\"")]
+        public void InvalidJson(string json)
+        {
+            AssertInvalidJson<Interval>(json, settings);
+        }
+
+        [Test]
+        public void Serialize_InObject()
+        {
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var interval = new Interval(startInstant, endInstant);
+
+            var testObject = new TestObject { Interval = interval };
+
+            var json = JsonConvert.SerializeObject(testObject, Formatting.None, settings);
+
+            string expectedJson = "{\"Interval\":\"2012-01-02T03:04:05Z/2013-06-07T08:09:10Z\"}";
+            Assert.AreEqual(expectedJson, json);
+        }
+
+        [Test]
+        public void Deserialize_InObject()
+        {
+            string json = "{\"Interval\":\"2012-01-02T03:04:05Z/2013-06-07T08:09:10Z\"}";
+
+            var testObject = JsonConvert.DeserializeObject<TestObject>(json, settings);
+
+            var interval = testObject.Interval;
+
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var expectedInterval = new Interval(startInstant, endInstant);
+            Assert.AreEqual(expectedInterval, interval);
+        }
+
+        public class TestObject
+        {
+            public Interval Interval { get; set; }
+        }
+    }
+}

--- a/src/NodaTime.Serialization.Test/SystemText/TestHelper.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/TestHelper.cs
@@ -33,7 +33,7 @@ namespace NodaTime.Serialization.Test.SystemText
 
         internal static void AssertInvalidJson<T>(string json, JsonSerializerOptions options)
         {
-            var exception = Assert.Throws<SerializationException>(() => JsonSerializer.Deserialize<T>(json, options));
+            var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<T>(json, options));
             Assert.IsInstanceOf<InvalidNodaDataException>(exception.InnerException);
         }
     }

--- a/src/NodaTime.Serialization.Test/SystemText/TestHelper.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/TestHelper.cs
@@ -1,9 +1,13 @@
-﻿// Copyright 2015 The Noda Time Authors. All rights reserved.
+﻿// Copyright 2019 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System.Runtime.Serialization;
+using System.Text.Json;
 using NodaTime.Utility;
 using NUnit.Framework;
+using JsonConverter = System.Text.Json.Serialization.JsonConverter;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace NodaTime.Serialization.Test.SystemText
 {
@@ -11,26 +15,25 @@ namespace NodaTime.Serialization.Test.SystemText
     {
         internal static void AssertConversions<T>(T value, string expectedJson, JsonConverter converter)
         {
-            var settings = new JsonSerializerSettings
+            var options = new JsonSerializerOptions
             {
                 Converters = { converter },
-                DateParseHandling = DateParseHandling.None
             };
-            AssertConversions(value, expectedJson, settings);
+            AssertConversions(value, expectedJson, options);
         }
 
-        internal static void AssertConversions<T>(T value, string expectedJson, JsonSerializerSettings settings)
+        internal static void AssertConversions<T>(T value, string expectedJson, JsonSerializerOptions options)
         {
-            var actualJson = JsonConvert.SerializeObject(value, Formatting.None, settings);
+            var actualJson = JsonSerializer.Serialize(value, options);
             Assert.AreEqual(expectedJson, actualJson);
 
-            var deserializedValue = JsonConvert.DeserializeObject<T>(expectedJson, settings);
+            var deserializedValue = JsonSerializer.Deserialize<T>(expectedJson, options);
             Assert.AreEqual(value, deserializedValue);
         }
 
-        internal static void AssertInvalidJson<T>(string json, JsonSerializerSettings settings)
+        internal static void AssertInvalidJson<T>(string json, JsonSerializerOptions options)
         {
-            var exception = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<T>(json, settings));
+            var exception = Assert.Throws<SerializationException>(() => JsonSerializer.Deserialize<T>(json, options));
             Assert.IsInstanceOf<InvalidNodaDataException>(exception.InnerException);
         }
     }

--- a/src/NodaTime.Serialization.Test/SystemText/TestHelper.cs
+++ b/src/NodaTime.Serialization.Test/SystemText/TestHelper.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2015 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Utility;
+using NUnit.Framework;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    internal static class TestHelper
+    {
+        internal static void AssertConversions<T>(T value, string expectedJson, JsonConverter converter)
+        {
+            var settings = new JsonSerializerSettings
+            {
+                Converters = { converter },
+                DateParseHandling = DateParseHandling.None
+            };
+            AssertConversions(value, expectedJson, settings);
+        }
+
+        internal static void AssertConversions<T>(T value, string expectedJson, JsonSerializerSettings settings)
+        {
+            var actualJson = JsonConvert.SerializeObject(value, Formatting.None, settings);
+            Assert.AreEqual(expectedJson, actualJson);
+
+            var deserializedValue = JsonConvert.DeserializeObject<T>(expectedJson, settings);
+            Assert.AreEqual(value, deserializedValue);
+        }
+
+        internal static void AssertInvalidJson<T>(string json, JsonSerializerSettings settings)
+        {
+            var exception = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<T>(json, settings));
+            Assert.IsInstanceOf<InvalidNodaDataException>(exception.InnerException);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.sln
+++ b/src/NodaTime.Serialization.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -9,6 +9,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaTime.Serialization.Benchmarks", "NodaTime.Serialization.Benchmarks\NodaTime.Serialization.Benchmarks.csproj", "{7E96596E-800E-4F71-9304-F1D0F6B9937B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaTime.Serialization.Protobuf", "NodaTime.Serialization.Protobuf\NodaTime.Serialization.Protobuf.csproj", "{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NodaTime.Serialization.SystemText", "NodaTime.Serialization.SystemText\NodaTime.Serialization.SystemText.csproj", "{3B4A09D5-F07E-435C-8546-F54509C1DC7A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -68,6 +70,18 @@ Global
 		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Release|x64.Build.0 = Release|Any CPU
 		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Release|x86.ActiveCfg = Release|Any CPU
 		{7F18FFC3-BF5A-46E5-B471-94D3F53C47AC}.Release|x86.Build.0 = Release|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Debug|x86.Build.0 = Debug|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Release|x64.Build.0 = Release|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is an initial implementation of System.Text.Json support. The code is mostly a copy of Json.Net serialization routine, since the API is very similar. There is a lot of potential for additional performance improvements, but for now I think compatibility is more important.

TODO:
- [ ] Fix unit tests. 
Some of them are failing due to `Utf8JsonWriter.WriteStringValue` method escaping the forward slash symbol. As of right now, I couldn't find a way to override this, and the API allowing it doesn't seem to be a part of preview 7 release (https://github.com/dotnet/corefx/issues/37192). Will get back to it at a later time.

Looking forward to comments/suggestions!