### PR TITLE
Add case-insensitive deserialization for JSON

### DIFF
--- a/src/NodaTime.Serialization.JsonNet/NodaDateIntervalConverter.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaDateIntervalConverter.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System;
 using Newtonsoft.Json;
 using NodaTime.Utility;
 
@@ -39,13 +40,13 @@ namespace NodaTime.Serialization.JsonNet
                 }
 
                 var startPropertyName = serializer.ResolvePropertyName(nameof(Interval.Start));
-                if (propertyName == startPropertyName)
+                if (string.Equals(propertyName, startPropertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     startLocalDate = serializer.Deserialize<LocalDate>(reader);
                 }
 
                 var endPropertyName = serializer.ResolvePropertyName(nameof(Interval.End));
-                if (propertyName == endPropertyName)
+                if (string.Equals(propertyName, endPropertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     endLocalDate = serializer.Deserialize<LocalDate>(reader);
                 }

--- a/src/NodaTime.Serialization.JsonNet/NodaIntervalConverter.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaIntervalConverter.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System;
 using Newtonsoft.Json;
 
 namespace NodaTime.Serialization.JsonNet
@@ -40,13 +41,13 @@ namespace NodaTime.Serialization.JsonNet
                 }
 
                 var startPropertyName = serializer.ResolvePropertyName(nameof(Interval.Start));
-                if (propertyName == startPropertyName)
+                if (string.Equals(propertyName, startPropertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     startInstant = serializer.Deserialize<Instant>(reader);
                 }
 
                 var endPropertyName = serializer.ResolvePropertyName(nameof(Interval.End));
-                if (propertyName == endPropertyName)
+                if (string.Equals(propertyName, endPropertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     endInstant = serializer.Deserialize<Instant>(reader);
                 }

--- a/src/NodaTime.Serialization.SystemTextJson/NodaDateIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaDateIntervalConverter.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System;
 using System.Text.Json;
 using NodaTime.Utility;
 
@@ -39,13 +40,13 @@ namespace NodaTime.Serialization.SystemTextJson
                 }
 
                 var startPropertyName = options.ResolvePropertyName(nameof(Interval.Start));
-                if (propertyName == startPropertyName)
+                if (string.Equals(propertyName, startPropertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     startLocalDate = options.ReadType<LocalDate>(ref reader);
                 }
 
                 var endPropertyName = options.ResolvePropertyName(nameof(Interval.End));
-                if (propertyName == endPropertyName)
+                if (string.Equals(propertyName, endPropertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     endLocalDate = options.ReadType<LocalDate>(ref reader);
                 }

--- a/src/NodaTime.Serialization.SystemTextJson/NodaDateIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaDateIntervalConverter.cs
@@ -39,14 +39,16 @@ namespace NodaTime.Serialization.SystemTextJson
                     break;
                 }
 
+                var caseSensitivity = options.PropertyNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
                 var startPropertyName = options.ResolvePropertyName(nameof(Interval.Start));
-                if (string.Equals(propertyName, startPropertyName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(propertyName, startPropertyName, caseSensitivity))
                 {
                     startLocalDate = options.ReadType<LocalDate>(ref reader);
                 }
 
                 var endPropertyName = options.ResolvePropertyName(nameof(Interval.End));
-                if (string.Equals(propertyName, endPropertyName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(propertyName, endPropertyName, caseSensitivity))
                 {
                     endLocalDate = options.ReadType<LocalDate>(ref reader);
                 }

--- a/src/NodaTime.Serialization.SystemTextJson/NodaIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaIntervalConverter.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System;
 using System.Text.Json;
 
 namespace NodaTime.Serialization.SystemTextJson
@@ -40,13 +41,13 @@ namespace NodaTime.Serialization.SystemTextJson
                 }
 
                 var startPropertyName = options.ResolvePropertyName(nameof(Interval.Start));
-                if (propertyName == startPropertyName)
+                if (string.Equals(propertyName, startPropertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     startInstant = options.ReadType<Instant>(ref reader);
                 }
 
                 var endPropertyName = options.ResolvePropertyName(nameof(Interval.End));
-                if (propertyName == endPropertyName)
+                if (string.Equals(propertyName, endPropertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     endInstant = options.ReadType<Instant>(ref reader);
                 }

--- a/src/NodaTime.Serialization.SystemTextJson/NodaIntervalConverter.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaIntervalConverter.cs
@@ -40,14 +40,16 @@ namespace NodaTime.Serialization.SystemTextJson
                     break;
                 }
 
+                var caseSensitivity = options.PropertyNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
                 var startPropertyName = options.ResolvePropertyName(nameof(Interval.Start));
-                if (string.Equals(propertyName, startPropertyName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(propertyName, startPropertyName, caseSensitivity))
                 {
                     startInstant = options.ReadType<Instant>(ref reader);
                 }
 
                 var endPropertyName = options.ResolvePropertyName(nameof(Interval.End));
-                if (string.Equals(propertyName, endPropertyName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(propertyName, endPropertyName, caseSensitivity))
                 {
                     endInstant = options.ReadType<Instant>(ref reader);
                 }

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaDateIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaDateIntervalConverterTest.cs
@@ -104,6 +104,42 @@ namespace NodaTime.Serialization.Test.JsonNet
             Assert.AreEqual(expectedInterval, interval);
         }
 
+        [Test]
+        public void Deserialize_CaseInsensitive()
+        {
+            string json = "{\"Interval\":{\"Start\":\"2012-01-02\",\"End\":\"2013-06-07\"}}";
+
+            var testObjectPascalCase = JsonConvert.DeserializeObject<TestObject>(json, settings);
+            var testObjectCamelCase = JsonConvert.DeserializeObject<TestObject>(json, settingsCamelCase);
+
+            var intervalPascalCase = testObjectPascalCase.Interval;
+            var intervalCamelCase = testObjectCamelCase.Interval;
+
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var expectedInterval = new DateInterval(startLocalDate, endLocalDate);
+            Assert.AreEqual(expectedInterval, intervalPascalCase);
+            Assert.AreEqual(expectedInterval, intervalCamelCase);
+        }
+
+        [Test]
+        public void Deserialize_CaseInsensitive_CamelCase()
+        {
+            string json = "{\"interval\":{\"start\":\"2012-01-02\",\"end\":\"2013-06-07\"}}";
+
+            var testObjectPascalCase = JsonConvert.DeserializeObject<TestObject>(json, settings);
+            var testObjectCamelCase = JsonConvert.DeserializeObject<TestObject>(json, settingsCamelCase);
+
+            var intervalPascalCase = testObjectPascalCase.Interval;
+            var intervalCamelCase = testObjectCamelCase.Interval;
+
+            var startLocalDate = new LocalDate(2012, 1, 2);
+            var endLocalDate = new LocalDate(2013, 6, 7);
+            var expectedInterval = new DateInterval(startLocalDate, endLocalDate);
+            Assert.AreEqual(expectedInterval, intervalPascalCase);
+            Assert.AreEqual(expectedInterval, intervalCamelCase);
+        }
+
         public class TestObject
         {
             public DateInterval Interval { get; set; }

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaIntervalConverterTest.cs
@@ -106,6 +106,42 @@ namespace NodaTime.Serialization.Test.JsonNet
             Assert.AreEqual(expectedInterval, interval);
         }
 
+        [Test]
+        public void Deserialize_CaseInsensitive()
+        {
+            string json = "{\"Interval\":{\"Start\":\"2012-01-02T03:04:05Z\",\"End\":\"2013-06-07T08:09:10Z\"}}";
+
+            var testObjectPascalCase = JsonConvert.DeserializeObject<TestObject>(json, settings);
+            var testObjectCamelCase = JsonConvert.DeserializeObject<TestObject>(json, settingsCamelCase);
+
+            var intervalPascalCase = testObjectPascalCase.Interval;
+            var intervalCamelCase = testObjectCamelCase.Interval;
+
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var expectedInterval = new Interval(startInstant, endInstant);
+            Assert.AreEqual(expectedInterval, intervalPascalCase);
+            Assert.AreEqual(expectedInterval, intervalCamelCase);
+        }
+
+        [Test]
+        public void Deserialize_CaseInsensitive_CamelCase()
+        {
+            string json = "{\"interval\":{\"start\":\"2012-01-02T03:04:05Z\",\"end\":\"2013-06-07T08:09:10Z\"}}";
+
+            var testObjectPascalCase = JsonConvert.DeserializeObject<TestObject>(json, settings);
+            var testObjectCamelCase = JsonConvert.DeserializeObject<TestObject>(json, settingsCamelCase);
+
+            var intervalPascalCase = testObjectPascalCase.Interval;
+            var intervalCamelCase = testObjectCamelCase.Interval;
+
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var expectedInterval = new Interval(startInstant, endInstant);
+            Assert.AreEqual(expectedInterval, intervalPascalCase);
+            Assert.AreEqual(expectedInterval, intervalCamelCase);
+        }
+
         public class TestObject
         {
             public Interval Interval { get; set; }

--- a/src/NodaTime.Serialization.Test/SystemTextJson/NodaIntervalConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemTextJson/NodaIntervalConverterTest.cs
@@ -16,10 +16,23 @@ namespace NodaTime.Serialization.Test.SystemText
             Converters = { NodaConverters.IntervalConverter, NodaConverters.InstantConverter },
         };
 
+        private readonly JsonSerializerOptions optionsCaseInsensitive = new JsonSerializerOptions
+        {
+            Converters = { NodaConverters.IntervalConverter, NodaConverters.InstantConverter },
+            PropertyNameCaseInsensitive = true,
+        };
+
         private readonly JsonSerializerOptions optionsCamelCase = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             Converters = { NodaConverters.IntervalConverter, NodaConverters.InstantConverter },
+        };
+
+        private readonly JsonSerializerOptions optionsCamelCaseCaseInsensitive = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { NodaConverters.IntervalConverter, NodaConverters.InstantConverter },
+            PropertyNameCaseInsensitive = true,
         };
 
         [Test]
@@ -98,6 +111,64 @@ namespace NodaTime.Serialization.Test.SystemText
             var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
             var expectedInterval = new Interval(startInstant, endInstant);
             Assert.AreEqual(expectedInterval, interval);
+        }
+
+        [Test]
+        public void Deserialize_CaseSensitive()
+        {
+            string json = "{\"Interval\":{\"Start\":\"2012-01-02T03:04:05Z\",\"end\":\"2013-06-07T08:09:10Z\"}}";
+
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, options); ;
+
+            Assert.True(testObject.Interval.HasStart);
+            Assert.False(testObject.Interval.HasEnd);
+        }
+
+        [Test]
+        public void Deserialize_CaseSensitive_CamelCase()
+        {
+            string json = "{\"interval\":{\"Start\":\"2012-01-02T03:04:05Z\",\"end\":\"2013-06-07T08:09:10Z\"}}";
+
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, optionsCamelCase); ;
+
+            Assert.False(testObject.Interval.HasStart);
+            Assert.True(testObject.Interval.HasEnd);
+        }
+
+        [Test]
+        public void Deserialize_CaseInsensitive()
+        {
+            string json = "{\"Interval\":{\"Start\":\"2012-01-02T03:04:05Z\",\"End\":\"2013-06-07T08:09:10Z\"}}";
+
+            var testObjectPascalCase = JsonSerializer.Deserialize<TestObject>(json, optionsCaseInsensitive); ;
+            var testObjectCamelCase = JsonSerializer.Deserialize<TestObject>(json, optionsCamelCaseCaseInsensitive); ;
+
+            var intervalPascalCase = testObjectPascalCase.Interval;
+            var intervalCamelCase = testObjectCamelCase.Interval;
+
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var expectedInterval = new Interval(startInstant, endInstant);
+            Assert.AreEqual(expectedInterval, intervalPascalCase);
+            Assert.AreEqual(expectedInterval, intervalCamelCase);
+        }
+
+        [Test]
+        public void Deserialize_CaseInsensitive_CamelCase()
+        {
+            string json = "{\"interval\":{\"start\":\"2012-01-02T03:04:05Z\",\"end\":\"2013-06-07T08:09:10Z\"}}";
+
+            var testObjectPascalCase = JsonSerializer.Deserialize<TestObject>(json, optionsCaseInsensitive);
+            var testObjectCamelCase = JsonSerializer.Deserialize<TestObject>(json, optionsCamelCaseCaseInsensitive);
+
+            var intervalPascalCase = testObjectPascalCase.Interval;
+            var intervalCamelCase = testObjectCamelCase.Interval;
+
+            var startInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            var endInstant = Instant.FromUtc(2013, 6, 7, 8, 9, 10);
+            var expectedInterval = new Interval(startInstant, endInstant);
+            Assert.AreEqual(expectedInterval, intervalPascalCase);
+            Assert.AreEqual(expectedInterval, intervalCamelCase);
         }
 
         public class TestObject


### PR DESCRIPTION
Compare property names in a case-insensitive way