### PR TITLE
Add Protobuf-net surrogate types for NodaTime types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.user
 *.sln.cache
 .vs
+.idea
 
 # IDE add-ins
 *.dotCover

--- a/src/NodaTime.Serialization.ProtobufNet/DurationSurrogate.cs
+++ b/src/NodaTime.Serialization.ProtobufNet/DurationSurrogate.cs
@@ -1,0 +1,41 @@
+﻿using System.Runtime.Serialization;
+using NodaTime.Serialization.Protobuf;
+using NodaDuration = NodaTime.Duration;
+using ProtobufDuration = Google.Protobuf.WellKnownTypes.Duration;
+
+namespace NodaTime.Serialization.ProtobufNet
+{
+    /// <summary>
+    /// Surrogate for <see cref="NodaTime.Duration"/>.
+    /// </summary>
+    [DataContract]
+    public class DurationSurrogate
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public DurationSurrogate()
+        {
+        }
+
+        /// <summary>
+        /// Constructor overload. 
+        /// </summary>
+        public DurationSurrogate(NodaDuration value) => Value = value.ToProtobufDuration();
+
+        /// <summary>
+        /// Stores the Google Protobuf Duration value for serialization.
+        /// </summary>
+        public ProtobufDuration Value { get; set; } = default!;
+
+        /// <summary>
+        /// Converts the surrogate to a <see cref="NodaTime.Duration"/>.
+        /// </summary>
+        public static implicit operator NodaDuration(DurationSurrogate surrogate) => surrogate.Value.ToNodaDuration();
+
+        /// <summary>
+        ///  Converts the <see cref="NodaTime.Duration"/> to a surrogate.
+        /// </summary>
+        public static implicit operator DurationSurrogate(NodaDuration source) => new DurationSurrogate(source);
+    }
+}

--- a/src/NodaTime.Serialization.ProtobufNet/InstantSurrogate.cs
+++ b/src/NodaTime.Serialization.ProtobufNet/InstantSurrogate.cs
@@ -1,0 +1,40 @@
+﻿using System.Runtime.Serialization;
+using Google.Protobuf.WellKnownTypes;
+using NodaTime.Serialization.Protobuf;
+
+namespace NodaTime.Serialization.ProtobufNet
+{
+    /// <summary>
+    /// Surrogate for <see cref="Instant"/>.
+    /// </summary>
+    [DataContract]
+    public class InstantSurrogate
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public InstantSurrogate()
+        {
+        }
+
+        /// <summary>
+        /// Constructor overload. 
+        /// </summary>
+        public InstantSurrogate(Instant value) => Value = value.ToTimestamp();
+
+        /// <summary>
+        /// Stores the Google Protobuf Timestamp value for serialization.
+        /// </summary>
+        public Timestamp Value { get; set; } = default!;
+
+        /// <summary>
+        /// Converts the surrogate to an <see cref="Instant"/>.
+        /// </summary>
+        public static implicit operator Instant(InstantSurrogate surrogate) => surrogate.Value.ToInstant();
+
+        /// <summary>
+        ///  Converts the <see cref="Instant"/> to a surrogate.
+        /// </summary>
+        public static implicit operator InstantSurrogate(Instant source) => new InstantSurrogate(source);
+    }
+}

--- a/src/NodaTime.Serialization.ProtobufNet/IsoDayOfWeekSurrogate.cs
+++ b/src/NodaTime.Serialization.ProtobufNet/IsoDayOfWeekSurrogate.cs
@@ -1,0 +1,40 @@
+﻿using System.Runtime.Serialization;
+using NodaTime.Serialization.Protobuf;
+using ProtobufDayOfWeek = Google.Type.DayOfWeek;
+
+namespace NodaTime.Serialization.ProtobufNet
+{
+    /// <summary>
+    /// Surrogate for <see cref="IsoDayOfWeek"/>.
+    /// </summary>
+    [DataContract]
+    public class IsoDayOfWeekSurrogate
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public IsoDayOfWeekSurrogate()
+        {
+        }
+
+        /// <summary>
+        /// Constructor overload. 
+        /// </summary>
+        public IsoDayOfWeekSurrogate(IsoDayOfWeek value) => Value = value.ToProtobufDayOfWeek();
+
+        /// <summary>
+        /// Stores the Google Protobuf DayOfWeek value for serialization.
+        /// </summary>
+        public ProtobufDayOfWeek Value { get; set; }
+
+        /// <summary>
+        /// Converts the surrogate to an <see cref="IsoDayOfWeek"/>.
+        /// </summary>
+        public static implicit operator IsoDayOfWeek(IsoDayOfWeekSurrogate surrogate) => surrogate.Value.ToIsoDayOfWeek();
+
+        /// <summary>
+        ///  Converts the <see cref="IsoDayOfWeek"/> to a surrogate.
+        /// </summary>
+        public static implicit operator IsoDayOfWeekSurrogate(IsoDayOfWeek source) => new IsoDayOfWeekSurrogate(source);
+    }
+}

--- a/src/NodaTime.Serialization.ProtobufNet/LocalDateSurrogate.cs
+++ b/src/NodaTime.Serialization.ProtobufNet/LocalDateSurrogate.cs
@@ -1,0 +1,40 @@
+﻿using System.Runtime.Serialization;
+using Google.Type;
+using NodaTime.Serialization.Protobuf;
+
+namespace NodaTime.Serialization.ProtobufNet
+{
+    /// <summary>
+    /// Surrogate for <see cref="LocalDate"/>.
+    /// </summary>
+    [DataContract]
+    public class LocalDateSurrogate
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public LocalDateSurrogate()
+        {
+        }
+
+        /// <summary>
+        /// Constructor overload. 
+        /// </summary>
+        public LocalDateSurrogate(LocalDate value) => Value = value.ToDate();
+
+        /// <summary>
+        /// Stores the Google Protobuf TimeOfDay value for serialization.
+        /// </summary>
+        public Date Value { get; set; } = default!;
+
+        /// <summary>
+        /// Converts the surrogate to a <see cref="LocalDate"/>.
+        /// </summary>
+        public static implicit operator LocalDate(LocalDateSurrogate surrogate) => surrogate.Value.ToLocalDate();
+
+        /// <summary>
+        ///  Converts the <see cref="LocalDate"/> to a surrogate.
+        /// </summary>
+        public static implicit operator LocalDateSurrogate(LocalDate source) => new LocalDateSurrogate(source);
+    }
+}

--- a/src/NodaTime.Serialization.ProtobufNet/LocalTimeSurrogate.cs
+++ b/src/NodaTime.Serialization.ProtobufNet/LocalTimeSurrogate.cs
@@ -1,0 +1,40 @@
+﻿using System.Runtime.Serialization;
+using Google.Type;
+using NodaTime.Serialization.Protobuf;
+
+namespace NodaTime.Serialization.ProtobufNet
+{
+    /// <summary>
+    /// Surrogate for <see cref="LocalTime"/>.
+    /// </summary>
+    [DataContract]
+    public class LocalTimeSurrogate
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public LocalTimeSurrogate()
+        {
+        }
+
+        /// <summary>
+        /// Constructor overload. 
+        /// </summary>
+        public LocalTimeSurrogate(LocalTime value) => Value = value.ToTimeOfDay();
+
+        /// <summary>
+        /// Stores the Google Protobuf TimeOfDay value for serialization.
+        /// </summary>
+        public TimeOfDay Value { get; set; } = default!;
+
+        /// <summary>
+        /// Converts the surrogate to a <see cref="LocalTime"/>.
+        /// </summary>
+        public static implicit operator LocalTime(LocalTimeSurrogate surrogate) => surrogate.Value.ToLocalTime();
+
+        /// <summary>
+        ///  Converts the <see cref="LocalTime"/> to a surrogate.
+        /// </summary>
+        public static implicit operator LocalTimeSurrogate(LocalTime source) => new LocalTimeSurrogate(source);
+    }
+}

--- a/src/NodaTime.Serialization.ProtobufNet/NodaTime.Serialization.ProtobufNet.csproj
+++ b/src/NodaTime.Serialization.ProtobufNet/NodaTime.Serialization.ProtobufNet.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Provides serialization support between Noda Time and protobuf-net</Description>
+        <Version>1.0.0</Version>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <PackageTags>nodatime;protobuf-net</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NodaTime" Version="[3.0.0,4.0.0)" />
+        <PackageReference Include="protobuf-net" Version="[3.0.0,4.0.0.0)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\NodaTime.Serialization.Protobuf\NodaTime.Serialization.Protobuf.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/NodaTime.Serialization.ProtobufNet/RuntimeTypeModelExtensions.cs
+++ b/src/NodaTime.Serialization.ProtobufNet/RuntimeTypeModelExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using ProtoBuf.Meta;
+
+namespace NodaTime.Serialization.ProtobufNet
+{
+    /// <summary>
+    /// Provides an extension method to conveniently register all NodaTime surrogate types with the default <see cref="RuntimeTypeModel"/>.
+    /// </summary>
+    public static class RuntimeTypeModelExtensions
+    {
+        private static readonly IDictionary<Type, Type> SurrogateMapping = new Dictionary<Type, Type>
+        {
+            [typeof(Duration)] = typeof(DurationSurrogate),
+            [typeof(Instant)] = typeof(InstantSurrogate),
+            [typeof(LocalTime)] = typeof(LocalTimeSurrogate),
+            [typeof(LocalDate)] = typeof(LocalDateSurrogate),
+            [typeof(IsoDayOfWeek)] = typeof(IsoDayOfWeekSurrogate),
+        };
+
+        /// <summary>
+        /// Register all NodaTime surrogate types with the protobuf runtime model.
+        /// </summary>
+        public static RuntimeTypeModel AddNodaTimeSurrogates(this RuntimeTypeModel runtimeTypeModel)
+        {
+            foreach (var map in SurrogateMapping) 
+                runtimeTypeModel.Add(map.Key, false).SetSurrogate(map.Value);
+            
+            return runtimeTypeModel;
+        }
+    }
+}

--- a/src/NodaTime.Serialization.sln
+++ b/src/NodaTime.Serialization.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MSBuild", "MSBuild", "{097D
 		..\Directory.Build.targets = ..\Directory.Build.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NodaTime.Serialization.ProtobufNet", "NodaTime.Serialization.ProtobufNet\NodaTime.Serialization.ProtobufNet.csproj", "{DFD32DEF-47CE-4603-940F-56C756B013B6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -89,6 +91,18 @@ Global
 		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Release|x64.Build.0 = Release|Any CPU
 		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Release|x86.ActiveCfg = Release|Any CPU
 		{3B4A09D5-F07E-435C-8546-F54509C1DC7A}.Release|x86.Build.0 = Release|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Debug|x64.Build.0 = Debug|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Debug|x86.Build.0 = Debug|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Release|x64.ActiveCfg = Release|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Release|x64.Build.0 = Release|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Release|x86.ActiveCfg = Release|Any CPU
+		{DFD32DEF-47CE-4603-940F-56C756B013B6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds a new serialization project that adds support for serializing NodaTime types to [protobuf-net.Grpc](https://github.com/protobuf-net/protobuf-net.Grpc) by adding surrogate types.

The PR also adds a convenience extension method on `Protobuf.Meta.RuntimeTypeModel` that registers these surrogates.

To add NodaTime serialization support when using protobuf-net.Grpc, simply add the following line in your Program class:

`RuntimeTypeModel.Default.AddNodaTimeSurrogates();`

For example:

```csharp
using System;
using NodaTime.Serialization.ProtobufNet;

namespace MyApplication
{
    public class Program
    {
        public static void Main()
        {
            RuntimeTypeModel.Default.AddNodaTimeSurrogates();
        }
    }
}
```

Now you can include NodaTime types in your grpc service contracts, e.g.

```csharp
public interface IMyAmazingService
{
   Task<MyAmazingResponse> DoAwesomeWorkAsync(MyAmazingRequest request);
}

[DataContract]
public class MyAmazingRequest
{
   [DataMember(Order = 1)] public Duration NeverEnding { get; set; }
   [DataMember(Order = 2)] public Instant ImportantMoment { get; set; }
   [DataMember(Order = 3)] public LocalDate MarkedDate { get; set; }
   [DataMember(Order = 4)] public LocalTime BestTimeEver { get; set; }
   [DataMember(Order = 5)] public IsoWeekOfDay PizzaDay { get; set; }
}

[DataContract]
public class MyAmazingResponse
{
   // I got nothing.
}
```

And it will just work.