### PR TITLE
Conditionally reference System.Text.Json

### DIFF
--- a/src/NodaTime.Serialization.SystemTextJson/NodaTime.Serialization.SystemTextJson.csproj
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaTime.Serialization.SystemTextJson.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <Description>Provides serialization support between Noda Time and System.Text.Json</Description>
     <Version>1.0.0</Version>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <PackageTags>nodatime;json</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="System.Text.Json" Version="4.7.1" />
+    <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will allow people who are targeting .netcoreapp3.1 to not have to pull down System.Text.Json from NuGet since it is provided by the runtime.