### PR TITLE
Add [proposed] rfc3339 zoned date time

### DIFF
--- a/src/NodaTime.Serialization.JsonNet/Extensions.cs
+++ b/src/NodaTime.Serialization.JsonNet/Extensions.cs
@@ -130,6 +130,36 @@ namespace NodaTime.Serialization.JsonNet
             return serializer;
         }
 
+        /// <summary>
+        /// </summary>
+        /// <param name="settings">The existing serializer settings to add Noda Time converters to.</param>
+        /// <param name="replacementConverter"></param>
+        /// <returns>The original <paramref name="settings"/> value, for further chaining.</returns>
+        public static JsonSerializerSettings WithReplacementNodaTimeConverter<T>(this JsonSerializerSettings settings, JsonConverter replacementConverter)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            ReplaceExistingConverters<T>(settings.Converters, replacementConverter);
+            return settings;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="serializer">The existing serializer to add Noda Time converters to.</param>
+        /// <param name="replacementConverter"></param>
+        /// <returns>The original <paramref name="serializer"/> value, for further chaining.</returns>
+        public static JsonSerializer WithReplacementNodaTimeConverter<T>(this JsonSerializer serializer, JsonConverter replacementConverter)
+        {
+            if (serializer == null)
+            {
+                throw new ArgumentNullException(nameof(serializer));
+            }
+            ReplaceExistingConverters<T>(serializer.Converters, replacementConverter);
+            return serializer;
+        }
+
         private static void AddDefaultConverters(IList<JsonConverter> converters, IDateTimeZoneProvider provider)
         {
             converters.Add(NodaConverters.InstantConverter);

--- a/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
@@ -107,6 +107,16 @@ namespace NodaTime.Serialization.JsonNet
                 CreateIsoValidator<ZonedDateTime>(x => x.Calendar));
 
         /// <summary>
+        /// Create a converter for zoned date/times that uses the format defined in the
+        /// [proposed] extension to RFC 3339 for indicating time zones in IANA format
+        /// </summary>
+        /// <returns></returns>
+        public static JsonConverter CreateZonedDateTimeRFC3339() =>
+            new NodaPatternConverter<ZonedDateTime>(
+                ZonedDateTimePattern.CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss;FFFo<G>'['z']'", DateTimeZoneProviders.Tzdb),
+                CreateIsoValidator<ZonedDateTime>(x => x.Calendar));
+
+        /// <summary>
         /// Creates a converter for time zones, using the given provider.
         /// </summary>
         /// <param name="provider">The time zone provider to use when parsing.</param>

--- a/src/NodaTime.Serialization.Test/JsonNet/ExtensionsTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/ExtensionsTest.cs
@@ -102,6 +102,31 @@ namespace NodaTime.Serialization.Test.JsonNet
                 JsonConvert.SerializeObject(interval, configuredSettings));
         }
 
+        [Test]
+        public void Settings_ConfigureForNodaTime_DefaultConverters()
+        {
+            var configuredSettings = new JsonSerializerSettings().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+            var explicitSettings = new JsonSerializerSettings
+            {
+                Converters = { NodaConverters.CreateZonedDateTimeConverter(DateTimeZoneProviders.Tzdb) }
+            };
+            var zone = DateTimeZoneProviders.Tzdb["Europe/London"];
+            var zonedDateTime = new ZonedDateTime(new LocalDateTime(2012, 10, 28, 1, 30), zone, Offset.FromHours(1));
+            Assert.AreEqual(JsonConvert.SerializeObject(zonedDateTime, explicitSettings),
+                JsonConvert.SerializeObject(zonedDateTime, configuredSettings));
+        }
+
+        [Test]
+        public void Settings_ConfigureForNodaTime_WithReplacementNodaConverter()
+        {
+            var configuredSettings = new JsonSerializerSettings().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb).WithReplacementNodaTimeConverter<ZonedDateTime>(NodaConverters.CreateZonedDateTimeRFC3339());
+            var explicitSettings = new JsonSerializerSettings { Converters = { NodaConverters.CreateZonedDateTimeRFC3339() } };
+            var zone = DateTimeZoneProviders.Tzdb["Europe/London"];
+            var zonedDateTime = new ZonedDateTime(new LocalDateTime(2012, 10, 28, 1, 30), zone, Offset.FromHours(1));
+            Assert.AreEqual(JsonConvert.SerializeObject(zonedDateTime, explicitSettings),
+                JsonConvert.SerializeObject(zonedDateTime, configuredSettings));
+        }
+
         private static string Serialize<T>(T value, JsonSerializer serializer)
         {
             var writer = new StringWriter();

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaConvertersTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaConvertersTest.cs
@@ -138,6 +138,28 @@ namespace NodaTime.Serialization.Test.JsonNet
         }
 
         [Test]
+        public void ZonedDateTimeRFC3339Converter_LocalTimeWithOffsetAndZone()
+        {
+            var zone = DateTimeZoneProviders.Tzdb["Europe/London"];
+            var value = new ZonedDateTime(new LocalDateTime(2012, 10, 28, 1, 30), zone, Offset.FromHours(1));
+            string json = "\"2012-10-28T01:30:00+01[Europe/London]\"";
+            var converter = NodaConverters.CreateZonedDateTimeRFC3339();
+
+            AssertConversions(value, json, converter);
+        }
+
+        [Test]
+        public void ZonedDateTimeRFC3339Converter_LocalTimeNoOffsetWithZoneAndMilliseconds()
+        {
+            var zone = DateTimeZoneProviders.Tzdb["Europe/London"];
+            var value = new ZonedDateTime(new LocalDateTime(2012, 10, 28, 1, 30).PlusMilliseconds(123), zone, Offset.FromHours(0));
+            string json = "\"2012-10-28T01:30:00.123Z[Europe/London]\"";
+            var converter = NodaConverters.CreateZonedDateTimeRFC3339();
+
+            AssertConversions(value, json, converter);
+        }
+
+        [Test]
         public void OffsetDateTimeConverter()
         {
             var value = new LocalDateTime(2012, 1, 2, 3, 4, 5).PlusNanoseconds(123456789).WithOffset(Offset.FromHoursAndMinutes(-1, -30));


### PR DESCRIPTION
PR to address #76 by adding support for the proposed RFC 3339 extension to date time formats to allow  serializing of time zone.

This would allow using a serialization format that is consistent with java and the pending Temporal proposal to ECMA/javascript