### PR TITLE
Safeguard for WebAssembly for the Sytem.Text.Json serializer

### DIFF
--- a/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
+++ b/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="NodaTime" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>

--- a/src/NodaTime.Serialization.SystemTextJson/NodaTime.Serialization.SystemTextJson.csproj
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaTime.Serialization.SystemTextJson.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="NodaTime" Version="[3.0.0,4.0.0)" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>


### PR DESCRIPTION
@jskeet 

I'm sure you could probably guess this was coming but same thing here for the Sytem.Text.Json project as that is the one we use for the WasmClient to be able serialize and deserialize the NodaTime structs even though we still use Json.NET on the server.

Same as [before](https://github.com/nodatime/nodatime/pull/1672) no need to do a release this is just guardrails for future contributors.

Buvy