### PR TITLE
Release NodaTime.Serialization.JsonNet 3.0.1

### DIFF
--- a/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
+++ b/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Provides serialization support between Noda Time and Json.NET.</Description>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageTags>nodatime;json;jsonnet</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
Changes since 3.0.0:

- Newtonsoft.Json dependency updated to 13.0.1
- "browser" constraint in supported platforms