### PR TITLE
Add NodaTimeDefaultJsonConverterAttribute

### DIFF
--- a/src/NodaTime.Serialization.SystemTextJson/NodaTimeDefaultConverterAttribute.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaTimeDefaultConverterAttribute.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2023 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NodaTime.Serialization.SystemTextJson;
+
+/// <summary>
+/// Provides JSON default converters for Noda Time types, as if using serializer
+/// options configured by <see cref="Extensions.ConfigureForNodaTime(JsonSerializerOptions, IDateTimeZoneProvider)"/>
+/// with a provider of <see cref="DateTimeZoneProviders.Tzdb"/>.
+/// </summary>
+/// <remarks>
+/// This attribute allows JSON conversion to be easily specified for properties without
+/// having to configure a specific options object.
+/// </remarks>
+public sealed class NodaTimeDefaultJsonConverterAttribute : JsonConverterAttribute
+{
+    private static readonly Dictionary<Type, JsonConverter> converters;
+
+    static NodaTimeDefaultJsonConverterAttribute()
+    {
+        converters = new()
+        {
+            { typeof(AnnualDate), NodaConverters.AnnualDateConverter },
+            { typeof(DateInterval), NodaConverters.DateIntervalConverter },
+            { typeof(DateTimeZone), NodaConverters.CreateDateTimeZoneConverter(DateTimeZoneProviders.Tzdb) },
+            { typeof(Duration), NodaConverters.DurationConverter },
+            { typeof(Instant), NodaConverters.InstantConverter },
+            { typeof(Interval), NodaConverters.IntervalConverter },
+            { typeof(LocalDate), NodaConverters.LocalDateConverter },
+            { typeof(LocalDateTime), NodaConverters.LocalDateTimeConverter },
+            { typeof(LocalTime), NodaConverters.LocalTimeConverter },
+            { typeof(Offset), NodaConverters.OffsetConverter },
+            { typeof(OffsetDate), NodaConverters.OffsetDateConverter },
+            { typeof(OffsetDateTime), NodaConverters.OffsetDateTimeConverter },
+            { typeof(OffsetTime), NodaConverters.OffsetTimeConverter },
+            { typeof(Period), NodaConverters.RoundtripPeriodConverter },
+            { typeof(ZonedDateTime), NodaConverters.CreateZonedDateTimeConverter(DateTimeZoneProviders.Tzdb) }
+        };
+        // Use the same converter for Nullable<T> as T.
+        foreach (var entry in converters.Where(pair => pair.Key.IsValueType).ToList())
+        {
+            converters[typeof(Nullable<>).MakeGenericType(entry.Key)] = entry.Value;
+        }
+    }
+
+    /// <inheritdoc />
+    public override JsonConverter CreateConverter(Type typeToConvert) =>
+        converters.TryGetValue(typeToConvert, out var converter) ? converter : null;
+}

--- a/src/NodaTime.Serialization.Test/SystemTextJson/NodaTimeDefaultConverterAttributeTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemTextJson/NodaTimeDefaultConverterAttributeTest.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2023 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Serialization.SystemTextJson;
+using NUnit.Framework;
+using System.Text.Json;
+
+namespace NodaTime.Serialization.Test.SystemTextJson;
+
+public class NodaTimeDefaultConverterAttributeTest
+{
+    [Test]
+    public void Roundtrip()
+    {
+        var obj = new SampleClass
+        {
+            NonNullableInstant = Instant.FromUtc(2023, 5, 29, 14, 11, 23),
+            NullableInstant1 = Instant.FromUtc(2025, 1, 2, 3, 4, 5),
+            NullableInstant2 = null,
+            ZonedDateTime = Instant.FromUtc(2023, 5, 29, 14, 11, 23).InZone(DateTimeZoneProviders.Tzdb["Europe/London"])
+        };
+
+        string json = JsonSerializer.Serialize(obj);
+        var result = JsonSerializer.Deserialize<SampleClass>(json);
+
+        Assert.AreEqual(obj.NonNullableInstant, result.NonNullableInstant);
+        Assert.AreEqual(obj.NullableInstant1, result.NullableInstant1);
+        Assert.Null(result.NullableInstant2);
+        Assert.AreEqual(obj.ZonedDateTime, result.ZonedDateTime);
+    }
+
+    // Just enough properties to check that the custom converters are being used.
+    public class SampleClass
+    {
+        [NodaTimeDefaultJsonConverter]
+        public Instant NonNullableInstant { get; set; }
+        [NodaTimeDefaultJsonConverter]
+        public Instant? NullableInstant1 { get; set; }
+        [NodaTimeDefaultJsonConverter]
+        public Instant? NullableInstant2 { get; set; }
+        [NodaTimeDefaultJsonConverter]
+        public ZonedDateTime ZonedDateTime { get; set; }
+    }
+}


### PR DESCRIPTION
This uses TZDB, which is what I think we should probably encourage.

This addresses the first part of #91; we can add more (e.g. for custom patterns) later if we want.