### PR TITLE
Release NodaTime.Serialization.Protobuf version 2.0.1

### DIFF
--- a/src/NodaTime.Serialization.Protobuf/NodaTime.Serialization.Protobuf.csproj
+++ b/src/NodaTime.Serialization.Protobuf/NodaTime.Serialization.Protobuf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Provides serialization support between Noda Time and Google.Protobuf</Description>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageTags>nodatime;google;protobuf</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
Changes since 2.0.0:

- No code changes
- Fixed link to source repository in NuGet
- Added README in NuGet package