### PR TITLE
Release NodaTime.Serialization.JsonNet version 3.1.0

### DIFF
--- a/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
+++ b/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Provides serialization support between Noda Time and Json.NET.</Description>
-    <Version>3.0.1</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageTags>nodatime;json;jsonnet</PackageTags>
   </PropertyGroup>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Changes since 3.0.0:

- Added NodaJsonSettings class for more fine-grained configuration
- Updated Newtonsoft.Json dependency to 13.0.3
- Added README to NuGet package
- Fixed link in NuGet gallery