### PR TITLE
Add simple support for a roundtrip duration pattern

### DIFF
--- a/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
@@ -115,10 +115,16 @@ namespace NodaTime.Serialization.JsonNet
             new NodaDateTimeZoneConverter(provider);
 
         /// <summary>
-        /// Converter for durations.
+        /// Converter for durations using <see cref="DurationPattern.JsonRoundtrip"/>.
         /// </summary>
         public static JsonConverter DurationConverter { get; }
-            = new NodaPatternConverter<Duration>(DurationPattern.CreateWithInvariantCulture("-H:mm:ss.FFFFFFFFF"));
+            = new NodaPatternConverter<Duration>(DurationPattern.JsonRoundtrip);
+
+        /// <summary>
+        /// Converter for durations using <see cref="DurationPattern.Roundtrip"/>.
+        /// </summary>
+        public static JsonConverter RoundtripDurationConverter { get; }
+            = new NodaPatternConverter<Duration>(DurationPattern.Roundtrip);
 
         /// <summary>
         /// Round-tripping converter for periods. Use this when you really want to preserve information,

--- a/src/NodaTime.Serialization.SystemTextJson/NodaConverters.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaConverters.cs
@@ -115,10 +115,16 @@ namespace NodaTime.Serialization.SystemTextJson
             new NodaDateTimeZoneConverter(provider);
 
         /// <summary>
-        /// Converter for durations.
+        /// Converter for durations using <see cref="DurationPattern.JsonRoundtrip"/>.
         /// </summary>
-        public static JsonConverter<Duration> DurationConverter { get; }
-            = new NodaPatternConverter<Duration>(DurationPattern.CreateWithInvariantCulture("-H:mm:ss.FFFFFFFFF"));
+        public static JsonConverter DurationConverter { get; }
+            = new NodaPatternConverter<Duration>(DurationPattern.JsonRoundtrip);
+
+        /// <summary>
+        /// Converter for durations using <see cref="DurationPattern.Roundtrip"/>.
+        /// </summary>
+        public static JsonConverter RoundtripDurationConverter { get; }
+            = new NodaPatternConverter<Duration>(DurationPattern.Roundtrip);
 
         /// <summary>
         /// Round-tripping converter for periods. Use this when you really want to preserve information,

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaConvertersTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaConvertersTest.cs
@@ -172,6 +172,12 @@ namespace NodaTime.Serialization.Test.JsonNet
         }
 
         [Test]
+        public void RoundtripDuration_WholeSeconds()
+        {
+            AssertConversions(Duration.FromHours(48), "\"2:00:00:00\"", NodaConverters.RoundtripDurationConverter);
+        }
+
+        [Test]
         public void Duration_FractionalSeconds()
         {
             AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromNanoseconds(123456789), "\"48:00:03.123456789\"", NodaConverters.DurationConverter);
@@ -181,10 +187,26 @@ namespace NodaTime.Serialization.Test.JsonNet
         }
 
         [Test]
+        public void RoundtripDuration_FractionalSeconds()
+        {
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromNanoseconds(123456789), "\"2:00:00:03.123456789\"", NodaConverters.RoundtripDurationConverter);
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromTicks(1230000), "\"2:00:00:03.123\"", NodaConverters.RoundtripDurationConverter);
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromTicks(1234000), "\"2:00:00:03.1234\"", NodaConverters.RoundtripDurationConverter);
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromTicks(12345), "\"2:00:00:03.0012345\"", NodaConverters.RoundtripDurationConverter);
+        }
+
+        [Test]
         public void Duration_MinAndMaxValues()
         {
             AssertConversions(Duration.FromTicks(long.MaxValue), "\"256204778:48:05.4775807\"", NodaConverters.DurationConverter);
             AssertConversions(Duration.FromTicks(long.MinValue), "\"-256204778:48:05.4775808\"", NodaConverters.DurationConverter);
+        }
+
+        [Test]
+        public void RoundtripDuration_MinAndMaxValues()
+        {
+            AssertConversions(Duration.FromTicks(long.MaxValue), "\"10675199:02:48:05.4775807\"", NodaConverters.RoundtripDurationConverter);
+            AssertConversions(Duration.FromTicks(long.MinValue), "\"-10675199:02:48:05.4775808\"", NodaConverters.RoundtripDurationConverter);
         }
 
         /// <summary>

--- a/src/NodaTime.Serialization.Test/SystemTextJson/NodaConvertersTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemTextJson/NodaConvertersTest.cs
@@ -191,6 +191,12 @@ namespace NodaTime.Serialization.Test.SystemText
         }
 
         [Test]
+        public void RoundtripDuration_WholeSeconds()
+        {
+            AssertConversions(Duration.FromHours(48), "\"2:00:00:00\"", NodaConverters.RoundtripDurationConverter);
+        }
+
+        [Test]
         public void Duration_FractionalSeconds()
         {
             AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromNanoseconds(123456789), "\"48:00:03.123456789\"", NodaConverters.DurationConverter);
@@ -200,10 +206,26 @@ namespace NodaTime.Serialization.Test.SystemText
         }
 
         [Test]
+        public void RoundtripDuration_FractionalSeconds()
+        {
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromNanoseconds(123456789), "\"2:00:00:03.123456789\"", NodaConverters.RoundtripDurationConverter);
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromTicks(1230000), "\"2:00:00:03.123\"", NodaConverters.RoundtripDurationConverter);
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromTicks(1234000), "\"2:00:00:03.1234\"", NodaConverters.RoundtripDurationConverter);
+            AssertConversions(Duration.FromHours(48) + Duration.FromSeconds(3) + Duration.FromTicks(12345), "\"2:00:00:03.0012345\"", NodaConverters.RoundtripDurationConverter);
+        }
+
+        [Test]
         public void Duration_MinAndMaxValues()
         {
             AssertConversions(Duration.FromTicks(long.MaxValue), "\"256204778:48:05.4775807\"", NodaConverters.DurationConverter);
             AssertConversions(Duration.FromTicks(long.MinValue), "\"-256204778:48:05.4775808\"", NodaConverters.DurationConverter);
+        }
+
+        [Test]
+        public void RoundtripDuration_MinAndMaxValues()
+        {
+            AssertConversions(Duration.FromTicks(long.MaxValue), "\"10675199:02:48:05.4775807\"", NodaConverters.RoundtripDurationConverter);
+            AssertConversions(Duration.FromTicks(long.MinValue), "\"-10675199:02:48:05.4775808\"", NodaConverters.RoundtripDurationConverter);
         }
 
         /// <summary>


### PR DESCRIPTION
(This is the pattern used by TypeConverter by default.)

Fixes #68.