### PR TITLE
Update all dependencies

### DIFF
--- a/src/NodaTime.Serialization.Benchmarks/NodaTime.Serialization.Benchmarks.csproj
+++ b/src/NodaTime.Serialization.Benchmarks/NodaTime.Serialization.Benchmarks.csproj
@@ -9,6 +9,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NodaTime.Serialization.JsonNet\NodaTime.Serialization.JsonNet.csproj" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 </Project>

--- a/src/NodaTime.Serialization.SystemTextJson/NodaTime.Serialization.SystemTextJson.csproj
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaTime.Serialization.SystemTextJson.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides serialization support between Noda Time and System.Text.Json</Description>
     <Version>1.1.2</Version>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <PackageTags>nodatime;json</PackageTags>
   </PropertyGroup>
 
@@ -13,6 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 </Project>

--- a/src/NodaTime.Serialization.Test/GlobalUsings.cs
+++ b/src/NodaTime.Serialization.Test/GlobalUsings.cs
@@ -1,0 +1,2 @@
+﻿// See https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html
+global using Assert = NUnit.Framework.Legacy.ClassicAssert;

--- a/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
+++ b/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NodaTime.Testing" Version="3.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NodaTime.Testing" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This also updates the non-netstandard target framework of NodaTime.Serialization.SystemTextJson to net6.0, and makes the dependency on System.Text.Json conditional (as it's already part of net6.0).