### PR TITLE
Release NodaTime.Serialization.SystemTextJson version 1.2.0

### DIFF
--- a/src/NodaTime.Serialization.SystemTextJson/NodaTime.Serialization.SystemTextJson.csproj
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaTime.Serialization.SystemTextJson.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Provides serialization support between Noda Time and System.Text.Json</Description>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <PackageTags>nodatime;json</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
Changes since 1.1.2:

- Added NodaConverters.RoundtripDurationConverter as a wrapper for DurationPattern.Roundtrip.
- Added a .NET 6.0 target (and removed the .NET Core 3.1 target; this will still be supported via .NET Standard 2.0, although .NET Core 3.1 is an unsupported platform now)
- Add support for using Noda Time types as dictionary keys in JSON (.NET 6.0 only)