### PR TITLE
Support for nullable with System.Text.Json source generator

### DIFF
--- a/src/NodaTime.Serialization.SystemTextJson/NodaConverters.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaConverters.cs
@@ -117,13 +117,19 @@ namespace NodaTime.Serialization.SystemTextJson
         /// <summary>
         /// Converter for durations using <see cref="DurationPattern.JsonRoundtrip"/>.
         /// </summary>
-        public static JsonConverter DurationConverter { get; }
+        public static JsonConverter DurationConverter => DurationConverterImpl;
+
+        // Note: this only exists because DurationConverter is non-generic.
+        internal static JsonConverter<Duration> DurationConverterImpl { get; }
             = new NodaPatternConverter<Duration>(DurationPattern.JsonRoundtrip);
 
         /// <summary>
         /// Converter for durations using <see cref="DurationPattern.Roundtrip"/>.
         /// </summary>
-        public static JsonConverter RoundtripDurationConverter { get; }
+        public static JsonConverter RoundtripDurationConverter => RoundtripDurationConverterImpl;
+
+        // Note: this only exists because RoundtripDurationConverter is non-generic.
+        internal static JsonConverter<Duration> RoundtripDurationConverterImpl { get; }
             = new NodaPatternConverter<Duration>(DurationPattern.Roundtrip);
 
         /// <summary>

--- a/src/NodaTime.Serialization.SystemTextJson/NodaNullableConverter.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaNullableConverter.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2023 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NodaTime.Serialization.SystemTextJson;
+
+internal class NodaNullableConverter<T> : JsonConverter<T?> where T : struct
+{
+    private readonly JsonConverter<T> _innerConverter;
+
+    public NodaNullableConverter(JsonConverter<T> innerConverter)
+    {
+        Preconditions.CheckNotNull(innerConverter, nameof(innerConverter));
+
+        _innerConverter = innerConverter;
+    }
+
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        return _innerConverter.Read(ref reader, typeToConvert, options);
+    }
+
+    public override void Write(Utf8JsonWriter writer, T? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            _innerConverter.Write(writer, value.Value, options);
+        }
+    }
+}

--- a/src/NodaTime.Serialization.SystemTextJson/NodaNullableConverter.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaNullableConverter.cs
@@ -8,10 +8,19 @@ using System.Text.Json.Serialization;
 
 namespace NodaTime.Serialization.SystemTextJson;
 
-internal class NodaNullableConverter<T> : JsonConverter<T?> where T : struct
+/// <summary>
+/// System.Text.Json converter for <see cref="Nullable{T}"/> value types, wrapping
+/// an inner converter.
+/// </summary>
+/// <typeparam name="T">Value type to be converted.</typeparam>
+internal sealed class NodaNullableConverter<T> : JsonConverter<T?> where T : struct
 {
     private readonly JsonConverter<T> _innerConverter;
 
+    /// <summary>
+    /// Creates a new NodaNullableConverter.
+    /// </summary>
+    /// <param name="innerConverter">Inner converter for serializing and deserializing when not null.</param>
     public NodaNullableConverter(JsonConverter<T> innerConverter)
     {
         Preconditions.CheckNotNull(innerConverter, nameof(innerConverter));
@@ -19,6 +28,7 @@ internal class NodaNullableConverter<T> : JsonConverter<T?> where T : struct
         _innerConverter = innerConverter;
     }
 
+    /// <inheritdoc />
     public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.Null)
@@ -29,6 +39,7 @@ internal class NodaNullableConverter<T> : JsonConverter<T?> where T : struct
         return _innerConverter.Read(ref reader, typeToConvert, options);
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, T? value, JsonSerializerOptions options)
     {
         if (value is null)

--- a/src/NodaTime.Serialization.SystemTextJson/NodaTimeDefaultJsonConverterFactory.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaTimeDefaultJsonConverterFactory.cs
@@ -37,26 +37,33 @@ public sealed class NodaTimeDefaultJsonConverterFactory : JsonConverterFactory
         var converters = new Dictionary<Type, JsonConverter>()
         {
             { typeof(AnnualDate), NodaConverters.AnnualDateConverter },
+            { typeof(AnnualDate?), CreateNullableConverter(NodaConverters.AnnualDateConverter) },
             { typeof(DateInterval), NodaConverters.DateIntervalConverter },
             { typeof(DateTimeZone), NodaConverters.CreateDateTimeZoneConverter(DateTimeZoneProviders.Tzdb) },
             { typeof(Duration), NodaConverters.DurationConverter },
+            { typeof(Duration?), CreateNullableConverter((JsonConverter<Duration>) NodaConverters.DurationConverter) },
             { typeof(Instant), NodaConverters.InstantConverter },
+            { typeof(Instant?), CreateNullableConverter(NodaConverters.InstantConverter) },
             { typeof(Interval), NodaConverters.IntervalConverter },
+            { typeof(Interval?), CreateNullableConverter(NodaConverters.IntervalConverter) },
             { typeof(LocalDate), NodaConverters.LocalDateConverter },
+            { typeof(LocalDate?), CreateNullableConverter(NodaConverters.LocalDateConverter) },
             { typeof(LocalDateTime), NodaConverters.LocalDateTimeConverter },
+            { typeof(LocalDateTime?), CreateNullableConverter(NodaConverters.LocalDateTimeConverter) },
             { typeof(LocalTime), NodaConverters.LocalTimeConverter },
+            { typeof(LocalTime?), CreateNullableConverter(NodaConverters.LocalTimeConverter) },
             { typeof(Offset), NodaConverters.OffsetConverter },
+            { typeof(Offset?), CreateNullableConverter(NodaConverters.OffsetConverter) },
             { typeof(OffsetDate), NodaConverters.OffsetDateConverter },
+            { typeof(OffsetDate?), CreateNullableConverter(NodaConverters.OffsetDateConverter) },
             { typeof(OffsetDateTime), NodaConverters.OffsetDateTimeConverter },
+            { typeof(OffsetDateTime?), CreateNullableConverter(NodaConverters.OffsetDateTimeConverter) },
             { typeof(OffsetTime), NodaConverters.OffsetTimeConverter },
+            { typeof(OffsetTime?), CreateNullableConverter(NodaConverters.OffsetTimeConverter) },
             { typeof(Period), NodaConverters.RoundtripPeriodConverter },
-            { typeof(ZonedDateTime), NodaConverters.CreateZonedDateTimeConverter(DateTimeZoneProviders.Tzdb) }
+            { typeof(ZonedDateTime), NodaConverters.CreateZonedDateTimeConverter(DateTimeZoneProviders.Tzdb) },
+            { typeof(ZonedDateTime?), CreateNullableConverter(NodaConverters.CreateZonedDateTimeConverter(DateTimeZoneProviders.Tzdb)) }
         };
-        // Use the same converter for Nullable<T> as T.
-        foreach (var entry in converters.Where(pair => pair.Key.IsValueType).ToList())
-        {
-            converters[typeof(Nullable<>).MakeGenericType(entry.Key)] = entry.Value;
-        }
         return converters;
     }
 
@@ -74,4 +81,10 @@ public sealed class NodaTimeDefaultJsonConverterFactory : JsonConverterFactory
     /// <inheritdoc />
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
         GetConverter(typeToConvert);
+
+    /// <summary>
+    /// Helper to construct a <see cref="NodaNullableConverter{T}"/> with generic type inference at the call site.
+    /// </summary>
+    private static NodaNullableConverter<T> CreateNullableConverter<T>(JsonConverter<T> innerConverter) where T : struct
+        => new NodaNullableConverter<T>(innerConverter);
 }

--- a/src/NodaTime.Serialization.Test/SystemTextJson/NodaNullableConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemTextJson/NodaNullableConverterTest.cs
@@ -1,0 +1,35 @@
+// Copyright 2019 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System.Text.Json;
+using NodaTime.Serialization.SystemTextJson;
+using NUnit.Framework;
+using static NodaTime.Serialization.Test.SystemText.TestHelper;
+
+namespace NodaTime.Serialization.Test.SystemText
+{
+    /// <summary>
+    /// Tests for the converters exposed in NodaConverters.
+    /// </summary>
+    public class NodaNullableConverterTest
+    {
+        [Test]
+        public void InstantConverter_NotNull()
+        {
+            Instant? value = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
+            string json = "\"2012-01-02T03:04:05Z\"";
+            var converter = new NodaTimeDefaultJsonConverterFactory().CreateConverter(typeof(Instant?), new JsonSerializerOptions());
+            AssertConversions(value, json, converter);
+        }
+
+        [Test]
+        public void InstantConverter_Null()
+        {
+            Instant? value = null;
+            string json = "null";
+            var converter = new NodaTimeDefaultJsonConverterFactory().CreateConverter(typeof(Instant?), new JsonSerializerOptions());
+            AssertConversions(value, json, converter);
+        }
+    }
+}


### PR DESCRIPTION
Converters inheriting from `JsonConverter<T>` can only handle `T`, they can't also handle `Nullable<T>` directly for value types because they don't inherit from `JsonConverter<Nullable<T>>`. Instead, we need to wrap these in a `NodaNullableConverter` that handles the null cases.

Fixes #127