### PR TITLE
Release NodaTime.Serialization.Protobuf version 2.0.2

### DIFF
--- a/src/NodaTime.Serialization.Protobuf/NodaTime.Serialization.Protobuf.csproj
+++ b/src/NodaTime.Serialization.Protobuf/NodaTime.Serialization.Protobuf.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides serialization support between Noda Time and Google.Protobuf</Description>
     <!-- Update this just before a release. -->
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <!-- Update this just after a release. -->
     <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
 


### PR DESCRIPTION
Changes since 2.0.1:

- Fix the link in the NuGet package readme