### PR TITLE
Improve the exception message when conversion fails because of invalid data

### DIFF
--- a/src/NodaTime.Serialization.SystemTextJson/NodaConverterBase.cs
+++ b/src/NodaTime.Serialization.SystemTextJson/NodaConverterBase.cs
@@ -49,7 +49,7 @@ namespace NodaTime.Serialization.SystemTextJson
         /// <param name="reader">The json reader to read data from.</param>
         /// <param name="objectType">The type to convert the JSON to.</param>
         /// <param name="options">A serializer options to use for any embedded deserialization.</param>
-        /// <exception cref="InvalidNodaDataException">The JSON was invalid for this converter.</exception>
+        /// <exception cref="JsonException">The JSON was invalid for this converter.</exception>
         /// <returns>The deserialized value.</returns>
         public override T Read(ref Utf8JsonReader reader, Type objectType, JsonSerializerOptions options)
         {
@@ -60,7 +60,7 @@ namespace NodaTime.Serialization.SystemTextJson
             }
             catch (Exception ex)
             {
-                throw new JsonException($"Cannot convert value to {objectType}", ex);
+                throw new JsonException(null, ex);
             }
         }
 
@@ -70,7 +70,7 @@ namespace NodaTime.Serialization.SystemTextJson
         /// <param name="reader">The json reader to read data from.</param>
         /// <param name="typeToConvert">The type to convert the JSON to.</param>
         /// <param name="options">A serializer options to use for any embedded deserialization.</param>
-        /// <exception cref="InvalidNodaDataException">The JSON was invalid for this converter.</exception>
+        /// <exception cref="JsonException">The JSON was invalid for this converter.</exception>
         /// <returns>The deserialized value.</returns>
         public override T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert,
             JsonSerializerOptions options)
@@ -82,7 +82,7 @@ namespace NodaTime.Serialization.SystemTextJson
             }
             catch (Exception ex)
             {
-                throw new JsonException($"Cannot convert value to {typeToConvert}", ex);
+                throw new JsonException(null, ex);
             }
         }
 

--- a/src/NodaTime.Serialization.Test/GlobalUsings.cs
+++ b/src/NodaTime.Serialization.Test/GlobalUsings.cs
@@ -1,2 +1,3 @@
 ﻿// See https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html
 global using Assert = NUnit.Framework.Legacy.ClassicAssert;
+global using StringAssert = NUnit.Framework.Legacy.StringAssert;

--- a/src/NodaTime.Serialization.Test/SystemTextJson/NodaConverterBaseTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemTextJson/NodaConverterBaseTest.cs
@@ -53,7 +53,7 @@ namespace NodaTime.Serialization.Test.SystemText
         {
             var options = CreateOptions<TestConverter>();
             var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(json, options));
-            Assert.AreEqual("Cannot convert value to System.Int32", exception.Message);
+            StringAssert.StartsWith("The JSON value could not be converted to System.Int32. Path: $ | LineNumber: 0 | BytePositionInLine: ", exception.Message);
         }
 
         [Test]

--- a/src/NodaTime.Serialization.Test/SystemTextJson/NodaConverterBaseTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemTextJson/NodaConverterBaseTest.cs
@@ -47,11 +47,13 @@ namespace NodaTime.Serialization.Test.SystemText
         }
 
         [Test]
-        public void Deserialize_NonNullableType_NullValue()
+        [TestCase("null")]
+        [TestCase("\"\"")]
+        public void Deserialize_NonNullableType_InvalidValue(string json)
         {
             var options = CreateOptions<TestConverter>();
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("null", options));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("\"\"", options));
+            var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(json, options));
+            Assert.AreEqual("Cannot convert value to System.Int32", exception.Message);
         }
 
         [Test]

--- a/src/NodaTime.Serialization.Test/SystemTextJson/NodaDateTimeZoneConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemTextJson/NodaDateTimeZoneConverterTest.cs
@@ -78,6 +78,7 @@ namespace NodaTime.Serialization.Test.SystemText
                     {
                         Converters = {converter}
                     }));
+            Assert.AreEqual("Cannot convert value to NodaTime.DateTimeZone", exception.Message);
             Assert.IsInstanceOf<InvalidNodaDataException>(exception.InnerException);
             Assert.AreEqual("Unexpected token parsing time zone. Expected String, got Number.", exception.InnerException.Message);
         }

--- a/src/NodaTime.Serialization.Test/SystemTextJson/NodaDateTimeZoneConverterTest.cs
+++ b/src/NodaTime.Serialization.Test/SystemTextJson/NodaDateTimeZoneConverterTest.cs
@@ -78,7 +78,7 @@ namespace NodaTime.Serialization.Test.SystemText
                     {
                         Converters = {converter}
                     }));
-            Assert.AreEqual("Cannot convert value to NodaTime.DateTimeZone", exception.Message);
+            Assert.AreEqual("The JSON value could not be converted to NodaTime.DateTimeZone. Path: $ | LineNumber: 0 | BytePositionInLine: 1.", exception.Message);
             Assert.IsInstanceOf<InvalidNodaDataException>(exception.InnerException);
             Assert.AreEqual("Unexpected token parsing time zone. Expected String, got Number.", exception.InnerException.Message);
         }


### PR DESCRIPTION
Before this pull request, the `JsonException` message is generic and does not include JSON path information.

> Cannot convert value to NodaTime.AnyType

After this pull request, the `JsonException` message includes the exact JSON path information where the conversion fails.

> The JSON value could not be converted to NodaTime.AnyType. Path: $ | LineNumber: 0 | BytePositionInLine: 1.

To achieve this, the `JsonException` must be thrown without a message, as documented on [How to write custom converters for JSON serialization / Error handling / JsonException](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to#jsonexception).

> If you throw a `JsonException` without a message, the serializer creates a message that includes the path to the part of the JSON that caused the error.